### PR TITLE
[Feature]: Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,103 @@
+name: Bug Report
+description: Report a reproducible bug or unexpected behavior.
+title: "[Bug]: "
+labels:
+  - bug
+  - triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please include enough detail for someone else to reproduce it.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened?
+      placeholder: Describe the issue clearly.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: List the exact steps that trigger the issue.
+      placeholder: |
+        1. Start the service with ...
+        2. Send ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What happened instead?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected Component
+      multiple: true
+      options:
+        - Discord bot
+        - MCP server
+        - Webhook server
+        - Daily event reminder
+        - Member database
+        - Docker/deployment
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options:
+        - Local
+        - Docker Compose
+        - Production
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or Traceback
+      description: Paste relevant logs. Remove tokens, API keys, and personal data.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add screenshots, payload examples, related links, or other context.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues before opening this one.
+          required: true
+        - label: I removed secrets and sensitive data from logs and examples.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,69 @@
+name: Feature Request
+description: Suggest an improvement or new capability.
+title: "[Feature]: "
+labels:
+  - enhancement
+  - triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Please focus on the problem and expected outcome.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem should this solve?
+      placeholder: It is difficult to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Solution
+      description: Describe the behavior or workflow you want.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Related Component
+      multiple: true
+      options:
+        - Discord bot
+        - MCP server
+        - Webhook server
+        - Daily event reminder
+        - Member database
+        - Docker/deployment
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any workaround or alternative approach you considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add examples, screenshots, links, or implementation notes.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to help implement this.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+## Summary
+
+<!-- Describe the change in 1-2 sentences. -->
+
+## Related Issue
+
+<!-- Link the issue this PR addresses, if any. -->
+Fixes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Configuration or deployment
+- [ ] Tests
+
+## Changes
+
+-
+-
+-
+
+## Testing
+
+<!-- Describe the commands or manual checks you ran. -->
+
+- [ ] Local tests or checks pass
+- [ ] Manual verification completed
+- [ ] Not tested; reason:
+
+## Impact Checklist
+
+- [ ] Discord bot behavior checked, if affected
+- [ ] MCP server behavior checked, if affected
+- [ ] Webhook behavior checked, if affected
+- [ ] Docker or compose changes checked, if affected
+- [ ] Environment variables documented, if changed
+- [ ] Logs do not expose secrets or sensitive data
+
+## Notes for Reviewers
+
+<!-- Add screenshots, logs, rollout notes, or anything reviewers should know. -->


### PR DESCRIPTION
## Summary
- Add a default pull request template for summary, related issue, testing, and impact checks.
- Add bug report and feature request issue forms tailored to this Python/Discord/MCP service.
- Enable blank issues while still providing structured forms.

## Test Plan
- [x] Parsed `.github/ISSUE_TEMPLATE/*.yml` with `python3` and PyYAML.

Closes #1
