### PR TITLE
[Feature]: add Makefile workflow shortcuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+.DEFAULT_GOAL := help
+
+PYTHON ?= uv run python
+UV ?= uv
+PYTEST ?= uv run pytest
+PRE_COMMIT ?= uv run pre-commit
+DOCKER_COMPOSE ?= docker compose
+
+.PHONY: help setup sync test precommit-install precommit docker-build docker-up docker-logs docker-down clean
+
+help: ## Show available targets.
+	@awk 'BEGIN {FS = ":.*## "; printf "Available targets:\n"} /^[a-zA-Z0-9_-]+:.*## / {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+sync: ## Sync the uv development environment.
+	$(UV) sync --dev
+
+setup: sync precommit-install ## Sync dependencies and install pre-commit hooks.
+
+test: ## Run the test suite.
+	$(PYTEST)
+
+precommit-install: ## Install pre-commit git hooks.
+	$(PRE_COMMIT) install
+
+precommit: ## Run pre-commit hooks against all files.
+	$(PRE_COMMIT) run --all-files
+
+docker-build: ## Build the Docker Compose services.
+	$(DOCKER_COMPOSE) build
+
+docker-up: ## Start Docker Compose services in the background.
+	$(DOCKER_COMPOSE) up -d
+
+docker-logs: ## Follow Docker Compose logs.
+	$(DOCKER_COMPOSE) logs -f
+
+docker-down: ## Stop Docker Compose services.
+	$(DOCKER_COMPOSE) down
+
+clean: ## Remove local test and Python cache files.
+	find . -type d \( -name __pycache__ -o -name .pytest_cache -o -name .ruff_cache \) -prune -exec rm -rf {} +
+	find . -type f -name "*.pyc" -delete

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ ntuai-watson-agent/
 ├── start.sh                # 容器啟動腳本（依序啟動各服務）
 ├── Dockerfile              # NVIDIA CUDA 12.1 + Python 3.11 映像
 ├── docker-compose.yml      # 含 GPU 支援與 ngrok tunnel
+├── Makefile              # 常用本機開發與 Docker 指令捷徑
 ├── .python-version       # uv 本機 Python 版本固定檔
 ├── .pre-commit-config.yaml # pre-commit 本機檢查設定
 ├── pyproject.toml        # Python 專案 metadata 與依賴群組
@@ -244,6 +245,21 @@ uv run ian discord
 ```
 
 FAISS 依賴在 `pyproject.toml` 以平台 marker 明確指定：macOS 安裝 `faiss-cpu`，Linux x86_64 / CUDA 容器安裝 `faiss-gpu-cu12`。
+
+常用工作流程也可透過 Makefile 執行：
+
+```bash
+make help
+make setup
+make sync
+make test
+make precommit
+make docker-build
+make docker-up
+make docker-logs
+make docker-down
+make clean
+```
 
 ### Pre-commit
 


### PR DESCRIPTION
## Summary

Add a repository-level Makefile that wraps common uv, pytest, CLI, pre-commit, Docker Compose, and cleanup workflows. Document the shortcuts in README so contributors do not need to copy long commands manually.

## Related Issue

Fixes #27

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [x] Configuration or deployment
- [ ] Tests

## Changes

- Add Makefile targets for sync, tests, CLI help, pre-commit, service entrypoints, Docker Compose lifecycle, and cleanup.
- Document the Makefile target list in README.
- Keep targets thin by delegating to existing `uv`, `ian`, pytest, pre-commit, and Docker Compose commands.

## Testing

- [x] Local tests or checks pass
- [x] Manual verification completed
- [ ] Not tested; reason:

Commands run:

```bash
make help
make cli
make test
make precommit
git diff --check
```

## Impact Checklist

- [ ] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [ ] Webhook behavior checked, if affected
- [x] Docker or compose changes checked, if affected
- [x] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

## Notes for Reviewers

Docker lifecycle targets default to `docker compose`; contributors can override with `DOCKER_COMPOSE=docker-compose make docker-up` if they use the legacy standalone Compose binary.
