### PR TITLE
[Refactor]: split webhook gateway modules

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,6 +11,8 @@
   │ ian.gateways             │◄──►│ ian.gateways             │
   │ - discord_bot            │    │ - mcp_server             │
   │ - webhook_server         │    │ - Hybrid RAG             │
+  │ - facebook_webhook       │    │                          │
+  │ - line_webhook           │    │                          │
   │                          │    │ - 課程 / 通知 / 綁定工具 │
   └────────────┬─────────────┘    └──────────────────────────┘
                │                              ▲
@@ -32,7 +34,7 @@
 
 ### 各層職責
 
-- **Gateway 層**：各平台入口。`ian.gateways.discord_bot` 處理 Discord Slash Commands；`ian.gateways.webhook_server` (Flask) 處理 Facebook Messenger 與 LINE Webhook。
+- **Gateway 層**：各平台入口。`ian.gateways.discord_bot` 處理 Discord Slash Commands；`ian.gateways.webhook_server` (Flask) 負責 Webhook route wiring，並委派給 `ian.gateways.facebook_webhook` 與 `ian.gateways.line_webhook` 處理 Facebook Messenger / LINE 平台細節。
 - **Host Agent Client**：`ian.services.agent_runtime` 使用 LangGraph `create_react_agent` 搭配 Google Gemini 3 Flash，透過 MCP 協定調用工具，並管理每位使用者的獨立對話 session。
 - **MCP Tool Server**：`ian.gateways.mcp_server` 以 FastMCP 框架透過 SSE 提供 RAG 搜尋、課程查詢、幹部通知、社員綁定、簽到碼產生、訂閱管理、個性備註等工具。
 - **Member DB**：`ian.services.member_store` 從 Google Apps Script API 同步社員資料至本地 JSON 快取，提供平台帳號查詢、角色辨識、Email 綁定、訂閱管理與個性備註功能。
@@ -154,7 +156,7 @@ ntuai-watson-agent/
 
 ### FB / LINE Webhook (`ian.gateways.webhook_server`)
 
-Flask Web Server，接收各平台 webhook 並在背景執行緒處理訊息。
+Flask Web Server，接收各平台 webhook 並在背景執行緒處理訊息。`webhook_server` 保留 Flask route 與健康檢查；Facebook Messenger 行為位於 `ian.gateways.facebook_webhook`，LINE 行為位於 `ian.gateways.line_webhook`，共用時間與聊天紀錄 helper 位於 `ian.gateways.messaging_common`。
 
 | 平台 | 端點 | 說明 |
 |------|------|------|

--- a/src/ian/config.py
+++ b/src/ian/config.py
@@ -42,6 +42,7 @@ LINE_CHANNEL_SECRET = _env("LINE_CHANNEL_SECRET")
 MEMBER_API_URL = _env("MEMBER_API_URL")
 MEMBER_API_KEY = _env("MEMBER_API_KEY")
 MEMBER_DB_FILE = DATA_DIR / "member_db.json"
+MEMBER_MAPPING_FILE = DATA_DIR / "member_mapping.csv"
 
 ALLOWED_DISCORD_CHANNELS = [
     c.strip() for c in _env("DISCORD_ALLOWED_CHANNELS").split(",") if c.strip()

--- a/src/ian/gateways/facebook_webhook.py
+++ b/src/ian/gateways/facebook_webhook.py
@@ -1,0 +1,186 @@
+import asyncio
+import threading
+import time
+
+import pandas as pd
+import requests
+
+from ian.config import MEMBER_MAPPING_FILE, PAGE_ACCESS_TOKEN
+from ian.gateways.messaging_common import (
+    eprint,
+    get_current_time,
+    save_chat_history,
+)
+from ian.services.agent_runtime import chat_with_agent, parse_no_response, start_dispatcher
+from ian.services.member_store import (
+    get_member_name as get_member_name_from_db,
+    get_member_role as get_member_role_from_db,
+)
+
+MAPPING_FILE_PATH = MEMBER_MAPPING_FILE
+
+PROCESSED_MESSAGES = {}
+PROCESSED_MESSAGES_LOCK = threading.Lock()
+CACHE_EXPIRATION_SECONDS = 600
+
+
+def cleanup_processed_messages():
+    with PROCESSED_MESSAGES_LOCK:
+        current_time = time.time()
+        expired_mids = [
+            mid
+            for mid, timestamp in PROCESSED_MESSAGES.items()
+            if current_time - timestamp > CACHE_EXPIRATION_SECONDS
+        ]
+        for mid in expired_mids:
+            del PROCESSED_MESSAGES[mid]
+
+
+def get_member_mapping(username: str, csv_path: str):
+    try:
+        df = pd.read_csv(csv_path)
+        features = df.columns.to_list()
+        account_col = "FB帳號"
+
+        if account_col not in features or "角色" not in features:
+            raise ValueError(f"CSV 檔案必須包含 '{account_col}' 和 '角色' 欄位")
+
+        mapping = dict(zip(df[account_col], df["角色"]))
+        return mapping.get(username.strip(), "非社員（尚未加入 AI 社）")
+    except Exception as e:
+        print(f"讀取檔案失敗：{e}")
+        return "非社員"
+
+
+async def send_typing_indicator(recipient_id, action="typing_on"):
+    url = f"https://graph.facebook.com/v18.0/me/messages?access_token={PAGE_ACCESS_TOKEN}"
+    data = {"recipient": {"id": recipient_id}, "sender_action": action}
+    headers = {"Content-Type": "application/json"}
+    try:
+        response = requests.post(url, headers=headers, json=data, timeout=3)
+        if response.status_code != 200:
+            print(f"發送 FB 輸入狀態失敗: {response.text}")
+    except requests.exceptions.RequestException as e:
+        print(f"發送 FB 輸入狀態時連線失敗: {e}")
+
+
+def get_fb_user_profile(sender_id):
+    url = f"https://graph.facebook.com/v18.0/{sender_id}"
+    params = {"fields": "first_name,last_name,profile_pic", "access_token": PAGE_ACCESS_TOKEN}
+    try:
+        response = requests.get(url, params=params, timeout=5)
+        if response.status_code == 200:
+            profile = response.json()
+            full_name = f"{profile.get('first_name', '')} {profile.get('last_name', '')}".strip()
+            return full_name
+        else:
+            print(f"取得 FB 使用者資訊失敗: {response.text}")
+            return None
+    except requests.exceptions.RequestException as e:
+        print(f"連線 Facebook 失敗: {e}")
+        return None
+
+
+def send_message(recipient_id, text):
+    url = f"https://graph.facebook.com/v18.0/me/messages?access_token={PAGE_ACCESS_TOKEN}"
+    payload = {"recipient": {"id": recipient_id}, "message": {"text": text}}
+    headers = {"Content-Type": "application/json"}
+    try:
+        response = requests.post(url, headers=headers, json=payload, timeout=10)
+        if response.status_code != 200:
+            print(f"傳送 FB 訊息失敗: {response.text}")
+    except requests.exceptions.RequestException as e:
+        print(f"發送 FB 訊息時連線失敗: {e}")
+
+
+def send_reaction(recipient_id, mid, emoji):
+    """Send a reaction emoji to a specific message via FB Graph API."""
+    url = f"https://graph.facebook.com/v18.0/me/messages?access_token={PAGE_ACCESS_TOKEN}"
+    payload = {
+        "recipient": {"id": recipient_id},
+        "sender_action": "react",
+        "payload": {
+            "message_id": mid,
+            "reaction": emoji,
+        },
+    }
+    headers = {"Content-Type": "application/json"}
+    try:
+        response = requests.post(url, headers=headers, json=payload, timeout=10)
+        if response.status_code != 200:
+            eprint(f"FB reaction 失敗: {response.text}")
+        else:
+            eprint(f"FB reaction 成功: {emoji}")
+    except requests.exceptions.RequestException as e:
+        eprint(f"發送 FB reaction 時連線失敗: {e}")
+
+
+async def process_message_task(sender_id, user_message, mid=None):
+    try:
+        await send_typing_indicator(sender_id, "typing_on")
+        user_name = get_fb_user_profile(sender_id) or get_member_name_from_db("FB", sender_id) or "FB訪客"
+        roles = get_member_role_from_db("FB", sender_id)
+        account_id = sender_id
+        if roles == "非社員":
+            csv_role = get_member_mapping(user_name, MAPPING_FILE_PATH)
+            if csv_role != "非社員（尚未加入 AI 社）":
+                roles = csv_role
+
+        print(f"收到 FB [{roles}]/{user_name} ({sender_id}) 的訊息：{user_message}")
+        print(f"傳送給 agent 的身分資訊: {roles}")
+
+        current_time = get_current_time()
+        start_dispatcher(user_name, current_time)
+        bot_response = await chat_with_agent(
+            sender_id,
+            user_name,
+            user_message,
+            roles,
+            current_time["timestamp"],
+            channel_id="NaN",
+            platform="FB",
+            account_id=account_id,
+        )
+
+        await send_typing_indicator(sender_id, "typing_off")
+
+        is_no_response, reaction_emoji = parse_no_response(bot_response)
+        if is_no_response:
+            eprint("FB: Agent 決定不回覆此訊息")
+            if reaction_emoji and mid:
+                send_reaction(sender_id, mid, reaction_emoji)
+            return
+
+        send_message(sender_id, bot_response)
+        save_chat_history(sender_id, user_name, user_message, bot_response, "FB")
+        print(f"FB 訊息處理完成並已回覆給 {user_name}")
+
+    except Exception as e:
+        print(f"背景訊息處理任務發生錯誤 (FB, {sender_id}): {e}")
+        send_message(sender_id, "😰 Ian 目前有點忙碌，請稍後再試。\nIan is currently busy. Please try again later.")
+
+
+def handle_facebook_messages(data):
+    cleanup_processed_messages()
+
+    for entry in data.get("entry", []):
+        for messaging_event in entry.get("messaging", []):
+            message_obj = messaging_event.get("message")
+
+            if message_obj and message_obj.get("text") and not message_obj.get("is_echo"):
+                mid = message_obj.get("mid")
+                if not mid:
+                    continue
+
+                with PROCESSED_MESSAGES_LOCK:
+                    if mid in PROCESSED_MESSAGES:
+                        print(f"偵測到重複的訊息 ID (mid: {mid})，已略過。")
+                        continue
+                    PROCESSED_MESSAGES[mid] = time.time()
+
+                sender_id = messaging_event["sender"]["id"]
+                user_message = message_obj["text"]
+
+                coro = process_message_task(sender_id, user_message, mid=mid)
+                thread = threading.Thread(target=asyncio.run, args=(coro,))
+                thread.start()

--- a/src/ian/gateways/line_webhook.py
+++ b/src/ian/gateways/line_webhook.py
@@ -1,0 +1,165 @@
+import asyncio
+import threading
+
+import requests
+from linebot import LineBotApi, WebhookHandler
+from linebot.models import MessageEvent, TextMessage, TextSendMessage
+
+from ian.config import LINE_ALLOWED_GROUPS, LINE_CHANNEL_ACCESS_TOKEN, LINE_CHANNEL_SECRET
+from ian.gateways.messaging_common import (
+    eprint,
+    get_current_time,
+    save_chat_history,
+)
+from ian.services.agent_runtime import (
+    add_log,
+    chat_with_agent,
+    parse_no_response,
+    start_dispatcher,
+)
+from ian.services.member_store import (
+    get_member_name as get_member_name_from_db,
+    get_member_role as get_member_role_from_db,
+)
+
+line_bot_api = LineBotApi(LINE_CHANNEL_ACCESS_TOKEN)
+line_handler = WebhookHandler(LINE_CHANNEL_SECRET)
+
+
+def get_line_user_profile(user_id):
+    """使用 LINE Profile API 取得使用者顯示名稱"""
+    try:
+        profile = line_bot_api.get_profile(user_id)
+        return profile.display_name
+    except Exception as e:
+        print(f"取得 LINE 使用者資訊失敗: {e}")
+        return get_member_name_from_db("LINE", user_id) or f"LINE_{user_id[:8]}"
+
+
+@line_handler.add(MessageEvent, message=TextMessage)
+def handle_line_message(event):
+    """處理 LINE 訊息事件。"""
+    user_text = event.message.text
+    user_id = event.source.user_id
+
+    source_type = "1on1"
+    chat_id = None
+    if hasattr(event.source, "group_id"):
+        chat_id = event.source.group_id
+        source_type = "group"
+    elif hasattr(event.source, "room_id"):
+        chat_id = event.source.room_id
+        source_type = "room"
+    else:
+        chat_id = event.source.user_id
+
+    if source_type != "1on1" and chat_id not in LINE_ALLOWED_GROUPS:
+        eprint(f"LINE: 來源 {chat_id} 不在白名單中，忽略")
+        return
+
+    actual_question = user_text.strip()
+
+    if not actual_question:
+        line_bot_api.reply_message(event.reply_token, TextSendMessage(text="請輸入您的問題！"))
+        return
+
+    eprint(f"LINE: [{source_type}:{chat_id}] 收到 {user_id} 的訊息: {actual_question}")
+
+    try:
+        loading_url = "https://api.line.me/v2/bot/chat/loading/start"
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {LINE_CHANNEL_ACCESS_TOKEN}",
+        }
+        loading_data = {
+            "chatId": chat_id,
+            "loadingSeconds": 20,
+        }
+        requests.post(loading_url, headers=headers, json=loading_data, timeout=3)
+    except Exception as e:
+        eprint(f"LINE: 載入動畫啟動失敗: {e}")
+
+    coro = process_line_message_task(event.reply_token, user_id, actual_question, chat_id, source_type)
+    thread = threading.Thread(target=asyncio.run, args=(coro,))
+    thread.start()
+
+
+async def process_line_message_task(reply_token, user_id, user_message, chat_id, source_type="group"):
+    """LINE 訊息背景處理任務。"""
+    try:
+        user_name = get_line_user_profile(user_id)
+        if source_type == "1on1":
+            roles = get_member_role_from_db("LINE", user_id)
+        else:
+            roles = "社員"
+
+        eprint(f"LINE: 處理 {user_name} 的訊息：{user_message}")
+
+        current_time = get_current_time()
+        start_dispatcher(user_name, current_time)
+        bot_response = await chat_with_agent(
+            user_id,
+            user_name,
+            user_message,
+            roles,
+            current_time["timestamp"],
+            channel_id=str(chat_id),
+            platform="LINE",
+            account_id=user_id,
+        )
+
+        is_no_response, _ = parse_no_response(bot_response)
+        if is_no_response:
+            eprint("LINE: Agent 決定不回覆此訊息")
+            return
+
+        if "已達今日使用上限" in bot_response:
+            eprint("LINE: 使用者已達上限，不回覆")
+            return
+
+        max_chunk_length = 2000
+        text_chunks = []
+
+        if len(bot_response) > max_chunk_length:
+            paragraphs = bot_response.split("\n\n")
+            current_chunk = ""
+
+            for para in paragraphs:
+                if len(current_chunk) + len(para) + 2 <= max_chunk_length:
+                    current_chunk += para + "\n\n"
+                else:
+                    if current_chunk:
+                        text_chunks.append(current_chunk.strip())
+                    current_chunk = para + "\n\n"
+
+            if current_chunk:
+                text_chunks.append(current_chunk.strip())
+        else:
+            text_chunks = [bot_response]
+
+        max_messages = 5
+        line_messages = []
+        for chunk in text_chunks[:max_messages]:
+            if chunk.strip():
+                line_messages.append(TextSendMessage(text=chunk.strip()))
+
+        if line_messages:
+            try:
+                line_bot_api.reply_message(reply_token, line_messages)
+                eprint(f"LINE: reply_message 成功 -> chat_id={chat_id}, 訊息數={len(line_messages)}")
+            except Exception as reply_err:
+                eprint(f"LINE: reply_message 失敗 -> chat_id={chat_id}, 錯誤: {reply_err}")
+                import traceback
+
+                eprint(traceback.format_exc())
+                return
+
+        save_chat_history(user_id, user_name, user_message, bot_response, "LINE")
+        eprint(f"LINE: 訊息處理完成並已回覆給 {user_name}")
+
+    except Exception as e:
+        eprint(f"LINE: 背景訊息處理任務發生錯誤: {e}")
+        import traceback
+
+        eprint(traceback.format_exc())
+        add_log("ERROR", error=str(e), context=f"LINE message processing for {user_id} in {chat_id}")

--- a/src/ian/gateways/messaging_common.py
+++ b/src/ian/gateways/messaging_common.py
@@ -1,0 +1,49 @@
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+UPLOAD_DIR = "uploads"
+CHAT_HISTORY_FILE = os.path.join(UPLOAD_DIR, "chat_history.json")
+
+
+def eprint(*args, **kwargs):
+    """Print to stderr."""
+    print(*args, file=sys.stderr, **kwargs)
+
+
+def get_current_time():
+    """回傳台灣時區 (UTC+8) 的時間資訊 dict。"""
+    now = datetime.now(timezone(timedelta(hours=8)))
+    return {
+        "nowdatetime": now.strftime("%Y/%m/%d %H:%M:%S"),
+        "nowday": now.strftime("%A"),
+        "timestamp": now.timestamp(),
+    }
+
+
+def save_chat_history(sender_id, user_name, user_message, bot_response, platform="FB"):
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+
+    history = []
+    if os.path.exists(CHAT_HISTORY_FILE):
+        with open(CHAT_HISTORY_FILE, "r", encoding="utf-8") as f:
+            try:
+                history = json.load(f)
+            except json.JSONDecodeError:
+                history = []
+
+    time_data = get_current_time()
+    history.append(
+        {
+            "timestamp": time_data["nowdatetime"],
+            "platform": platform,
+            "sender_id": sender_id,
+            "user_name": user_name,
+            "user_message": user_message,
+            "bot_response": bot_response,
+        }
+    )
+
+    with open(CHAT_HISTORY_FILE, "w", encoding="utf-8") as f:
+        json.dump(history, f, ensure_ascii=False, indent=2)

--- a/src/ian/gateways/webhook_server.py
+++ b/src/ian/gateways/webhook_server.py
@@ -1,61 +1,14 @@
-import asyncio
-import json
-import os
-import sys
-import threading
-import time
-from datetime import datetime, timedelta, timezone
-
-import pandas as pd
-import requests
 from flask import Flask, abort, request
-from linebot import LineBotApi, WebhookHandler
 from linebot.exceptions import InvalidSignatureError
-from linebot.models import MessageEvent, TextMessage, TextSendMessage
 
-from ian.config import (
-    FB_VERIFY_TOKEN,
-    LINE_ALLOWED_GROUPS,
-    LINE_CHANNEL_ACCESS_TOKEN,
-    LINE_CHANNEL_SECRET,
-    PAGE_ACCESS_TOKEN,
-)
-from ian.services.agent_runtime import (
-    add_log,
-    chat_with_agent,
-    parse_no_response,
-    start_dispatcher,
-)
-from ian.services.member_store import (
-    get_member_name as get_member_name_from_db,
-    get_member_role as get_member_role_from_db,
-    init as init_member_db,
-)
-
-
-def eprint(*args, **kwargs):
-    """Print to stderr."""
-    print(*args, file=sys.stderr, **kwargs)
+from ian.config import FB_VERIFY_TOKEN
+from ian.gateways import facebook_webhook, line_webhook
+from ian.gateways.messaging_common import eprint, get_current_time
+from ian.services.member_store import init as init_member_db
 
 app = Flask(__name__)
 
-# ====== Facebook Configuration ======
 VERIFY_TOKEN = FB_VERIFY_TOKEN
-UPLOAD_DIR = "uploads"
-CHAT_HISTORY_FILE = os.path.join(UPLOAD_DIR, "chat_history.json")
-MAPPING_FILE_PATH = "./data/member_mapping.csv"
-
-# ====== LINE Bot Configuration ======
-line_bot_api = LineBotApi(LINE_CHANNEL_ACCESS_TOKEN)
-line_handler = WebhookHandler(LINE_CHANNEL_SECRET)
-
-# ====== Message Deduplication Cache ======
-PROCESSED_MESSAGES = {}
-PROCESSED_MESSAGES_LOCK = threading.Lock()
-CACHE_EXPIRATION_SECONDS = 600
-
-if not os.path.exists(UPLOAD_DIR):
-    os.makedirs(UPLOAD_DIR)
 
 # Initialize member database
 try:
@@ -64,173 +17,7 @@ try:
 except Exception as e:
     eprint(f"社員資料庫初始化失敗: {e}")
 
-def run_async_in_thread(coro):
-    """在獨立執行緒中執行協程。"""
-    asyncio.run(coro)
 
-# ====== Utility Functions ======
-def cleanup_processed_messages():
-    with PROCESSED_MESSAGES_LOCK:
-        current_time = time.time()
-        expired_mids = [
-            mid for mid, timestamp in PROCESSED_MESSAGES.items()
-            if current_time - timestamp > CACHE_EXPIRATION_SECONDS
-        ]
-        for mid in expired_mids:
-            del PROCESSED_MESSAGES[mid]
-
-def get_current_time():
-    """回傳台灣時區 (UTC+8) 的時間資訊 dict。"""
-    now = datetime.now(timezone(timedelta(hours=8)))
-    return {
-        "nowdatetime": now.strftime("%Y/%m/%d %H:%M:%S"),
-        "nowday": now.strftime("%A"),
-        "timestamp": now.timestamp()
-    }
-
-def get_member_mapping(username: str, csv_path: str):
-    try:
-        df = pd.read_csv(csv_path)
-        features = df.columns.to_list()
-        account_col = 'FB帳號'
-
-        if account_col not in features or '角色' not in features:
-            raise ValueError(f"CSV 檔案必須包含 '{account_col}' 和 '角色' 欄位")
-
-        mapping = dict(zip(df[account_col], df['角色']))
-        return mapping.get(username.strip(), "非社員（尚未加入 AI 社）")
-    except Exception as e:
-        print(f"讀取檔案失敗：{e}")
-        return "非社員"
-
-async def send_typing_indicator(recipient_id, action='typing_on'):
-    url = f"https://graph.facebook.com/v18.0/me/messages?access_token={PAGE_ACCESS_TOKEN}"
-    data = {"recipient": {"id": recipient_id}, "sender_action": action}
-    headers = {"Content-Type": "application/json"}
-    try:
-        response = requests.post(url, headers=headers, json=data, timeout=3)
-        if response.status_code != 200:
-            print(f"發送 FB 輸入狀態失敗: {response.text}")
-    except requests.exceptions.RequestException as e:
-        print(f"發送 FB 輸入狀態時連線失敗: {e}")
-
-def save_chat_history(sender_id, user_name, user_message, bot_response, platform="FB"):
-    history = []
-    if os.path.exists(CHAT_HISTORY_FILE):
-        with open(CHAT_HISTORY_FILE, 'r', encoding='utf-8') as f:
-            try:
-                history = json.load(f)
-            except json.JSONDecodeError:
-                history = []
-
-    time_data = get_current_time()
-    history.append({
-        "timestamp": time_data["nowdatetime"],
-        "platform": platform,
-        "sender_id": sender_id,
-        "user_name": user_name,
-        "user_message": user_message,
-        "bot_response": bot_response,
-    })
-
-    with open(CHAT_HISTORY_FILE, 'w', encoding='utf-8') as f:
-        json.dump(history, f, ensure_ascii=False, indent=2)
-
-def get_fb_user_profile(sender_id):
-    url = f"https://graph.facebook.com/v18.0/{sender_id}"
-    params = {"fields": "first_name,last_name,profile_pic", "access_token": PAGE_ACCESS_TOKEN}
-    try:
-        response = requests.get(url, params=params, timeout=5)
-        if response.status_code == 200:
-            profile = response.json()
-            full_name = f"{profile.get('first_name', '')} {profile.get('last_name', '')}".strip()
-            return full_name
-        else:
-            print(f"取得 FB 使用者資訊失敗: {response.text}")
-            return None
-    except requests.exceptions.RequestException as e:
-        print(f"連線 Facebook 失敗: {e}")
-        return None
-
-def get_line_user_profile(user_id):
-    """使用 LINE Profile API 取得使用者顯示名稱"""
-    try:
-        profile = line_bot_api.get_profile(user_id)
-        return profile.display_name
-    except Exception as e:
-        print(f"取得 LINE 使用者資訊失敗: {e}")
-        return get_member_name_from_db("LINE", user_id) or f"LINE_{user_id[:8]}"
-
-def send_message(recipient_id, text):
-    url = f"https://graph.facebook.com/v18.0/me/messages?access_token={PAGE_ACCESS_TOKEN}"
-    payload = {"recipient": {"id": recipient_id}, "message": {"text": text}}
-    headers = {"Content-Type": "application/json"}
-    try:
-        response = requests.post(url, headers=headers, json=payload, timeout=10)
-        if response.status_code != 200:
-            print(f"傳送 FB 訊息失敗: {response.text}")
-    except requests.exceptions.RequestException as e:
-        print(f"發送 FB 訊息時連線失敗: {e}")
-
-def send_reaction(recipient_id, mid, emoji):
-    """Send a reaction emoji to a specific message via FB Graph API."""
-    url = f"https://graph.facebook.com/v18.0/me/messages?access_token={PAGE_ACCESS_TOKEN}"
-    payload = {
-        "recipient": {"id": recipient_id},
-        "sender_action": "react",
-        "payload": {
-            "message_id": mid,
-            "reaction": emoji,
-        },
-    }
-    headers = {"Content-Type": "application/json"}
-    try:
-        response = requests.post(url, headers=headers, json=payload, timeout=10)
-        if response.status_code != 200:
-            eprint(f"FB reaction 失敗: {response.text}")
-        else:
-            eprint(f"FB reaction 成功: {emoji}")
-    except requests.exceptions.RequestException as e:
-        eprint(f"發送 FB reaction 時連線失敗: {e}")
-
-# ====== Background Message Processing ======
-async def process_message_task(sender_id, user_message, mid=None):
-    try:
-        await send_typing_indicator(sender_id, 'typing_on')
-        user_name = get_fb_user_profile(sender_id) or get_member_name_from_db("FB", sender_id) or "FB訪客"
-        # Use member DB first (by sender_id), fall back to CSV
-        roles = get_member_role_from_db("FB", sender_id)
-        account_id = sender_id
-        if roles == "非社員":
-            csv_role = get_member_mapping(user_name, MAPPING_FILE_PATH)
-            if csv_role != "非社員（尚未加入 AI 社）":
-                roles = csv_role
-
-        print(f"收到 FB [{roles}]/{user_name} ({sender_id}) 的訊息：{user_message}")
-        print(f"傳送給 agent 的身分資訊: {roles}")
-
-        current_time = get_current_time()
-        start_dispatcher(user_name, current_time)
-        bot_response = await chat_with_agent(sender_id, user_name, user_message, roles, current_time["timestamp"], channel_id="NaN", platform="FB", account_id=account_id)
-
-        await send_typing_indicator(sender_id, 'typing_off')
-
-        is_no_response, reaction_emoji = parse_no_response(bot_response)
-        if is_no_response:
-            eprint("FB: Agent 決定不回覆此訊息")
-            if reaction_emoji and mid:
-                send_reaction(sender_id, mid, reaction_emoji)
-            return
-
-        send_message(sender_id, bot_response)
-        save_chat_history(sender_id, user_name, user_message, bot_response, "FB")
-        print(f"FB 訊息處理完成並已回覆給 {user_name}")
-
-    except Exception as e:
-        print(f"背景訊息處理任務發生錯誤 (FB, {sender_id}): {e}")
-        send_message(sender_id, "😰 Ian 目前有點忙碌，請稍後再試。\nIan is currently busy. Please try again later.")
-
-# ====== Flask 路由 ======
 @app.route('/', methods=['GET'])
 async def verify():
     if request.args.get("hub.mode") == "subscribe" and request.args.get("hub.challenge"):
@@ -244,38 +31,12 @@ async def webhook():
     data = request.get_json()
     try:
         if data.get('object') == 'page':
-            handle_facebook_messages(data)
+            facebook_webhook.handle_facebook_messages(data)
     except Exception as e:
         print(f"Webhook 處理過程中發生未知錯誤: {e}")
     return "ok", 200
 
-# ====== Message Dispatch ======
-def handle_facebook_messages(data):
-    cleanup_processed_messages()
 
-    for entry in data.get('entry', []):
-        for messaging_event in entry.get('messaging', []):
-            message_obj = messaging_event.get('message')
-
-            if message_obj and message_obj.get('text') and not message_obj.get('is_echo'):
-                mid = message_obj.get('mid')
-                if not mid:
-                    continue
-
-                with PROCESSED_MESSAGES_LOCK:
-                    if mid in PROCESSED_MESSAGES:
-                        print(f"偵測到重複的訊息 ID (mid: {mid})，已略過。")
-                        continue
-                    PROCESSED_MESSAGES[mid] = time.time()
-
-                sender_id = messaging_event['sender']['id']
-                user_message = message_obj['text']
-
-                coro = process_message_task(sender_id, user_message, mid=mid)
-                thread = threading.Thread(target=run_async_in_thread, args=(coro,))
-                thread.start()
-
-# ====== LINE Webhook ======
 @app.route('/line/callback', methods=['POST'])
 def line_callback():
     """LINE webhook 接收端點。"""
@@ -283,7 +44,7 @@ def line_callback():
     body = request.get_data(as_text=True)
 
     try:
-        line_handler.handle(body, signature)
+        line_webhook.line_handler.handle(body, signature)
     except InvalidSignatureError:
         eprint("LINE: Invalid signature")
         abort(400)
@@ -292,139 +53,7 @@ def line_callback():
 
     return "OK", 200
 
-@line_handler.add(MessageEvent, message=TextMessage)
-def handle_line_message(event):
-    """處理 LINE 訊息事件。"""
-    user_text = event.message.text
-    user_id = event.source.user_id
 
-    source_type = "1on1"
-    chat_id = None
-    if hasattr(event.source, 'group_id'):
-        chat_id = event.source.group_id
-        source_type = "group"
-    elif hasattr(event.source, 'room_id'):
-        chat_id = event.source.room_id
-        source_type = "room"
-    else:
-        chat_id = event.source.user_id
-
-    if source_type != "1on1" and chat_id not in LINE_ALLOWED_GROUPS:
-        eprint(f"LINE: 來源 {chat_id} 不在白名單中，忽略")
-        return
-
-    actual_question = user_text.strip()
-
-    if not actual_question:
-        line_bot_api.reply_message(
-            event.reply_token,
-            TextSendMessage(text="請輸入您的問題！")
-        )
-        return
-
-    eprint(f"LINE: [{source_type}:{chat_id}] 收到 {user_id} 的訊息: {actual_question}")
-
-    # 顯示 LINE 載入動畫
-    try:
-        loading_url = 'https://api.line.me/v2/bot/chat/loading/start'
-        headers = {
-            'Content-Type': 'application/json',
-            'Authorization': f'Bearer {LINE_CHANNEL_ACCESS_TOKEN}'
-        }
-        loading_data = {
-            'chatId': chat_id,
-            'loadingSeconds': 20
-        }
-        requests.post(loading_url, headers=headers, json=loading_data, timeout=3)
-    except Exception as e:
-        eprint(f"LINE: 載入動畫啟動失敗: {e}")
-
-    coro = process_line_message_task(event.reply_token, user_id, actual_question, chat_id, source_type)
-    thread = threading.Thread(target=run_async_in_thread, args=(coro,))
-    thread.start()
-
-async def process_line_message_task(reply_token, user_id, user_message, chat_id, source_type="group"):
-    """LINE 訊息背景處理任務。"""
-    try:
-        user_name = get_line_user_profile(user_id)
-        if source_type == "1on1":
-            roles = get_member_role_from_db("LINE", user_id)
-        else:
-            roles = "社員"  # 白名單群組預設為社員
-
-        eprint(f"LINE: 處理 {user_name} 的訊息：{user_message}")
-
-        current_time = get_current_time()
-        start_dispatcher(user_name, current_time)
-        bot_response = await chat_with_agent(
-            user_id,
-            user_name,
-            user_message,
-            roles,
-            current_time["timestamp"],
-            channel_id=str(chat_id),
-            platform="LINE",
-            account_id=user_id,
-        )
-
-        is_no_response, _ = parse_no_response(bot_response)
-        if is_no_response:
-            eprint("LINE: Agent 決定不回覆此訊息")
-            return
-
-        if "已達今日使用上限" in bot_response:
-            eprint("LINE: 使用者已達上限，不回覆")
-            return
-
-        # 處理長訊息分段
-        MAX_CHUNK_LENGTH = 2000
-        text_chunks = []
-
-        if len(bot_response) > MAX_CHUNK_LENGTH:
-            # 先嘗試用雙換行分段
-            paragraphs = bot_response.split("\n\n")
-            current_chunk = ""
-
-            for para in paragraphs:
-                if len(current_chunk) + len(para) + 2 <= MAX_CHUNK_LENGTH:
-                    current_chunk += para + "\n\n"
-                else:
-                    if current_chunk:
-                        text_chunks.append(current_chunk.strip())
-                    current_chunk = para + "\n\n"
-
-            if current_chunk:
-                text_chunks.append(current_chunk.strip())
-        else:
-            text_chunks = [bot_response]
-
-        # 產生 LINE 訊息（最多 5 則）
-        MAX_MESSAGES = 5
-        line_messages = []
-        for chunk in text_chunks[:MAX_MESSAGES]:
-            if chunk.strip():
-                line_messages.append(TextSendMessage(text=chunk.strip()))
-
-        if line_messages:
-            try:
-                line_bot_api.reply_message(reply_token, line_messages)
-                eprint(f"LINE: reply_message 成功 -> chat_id={chat_id}, 訊息數={len(line_messages)}")
-            except Exception as reply_err:
-                eprint(f"LINE: reply_message 失敗 -> chat_id={chat_id}, 錯誤: {reply_err}")
-                import traceback
-                eprint(traceback.format_exc())
-                return
-
-        save_chat_history(user_id, user_name, user_message, bot_response, "LINE")
-        eprint(f"LINE: 訊息處理完成並已回覆給 {user_name}")
-
-    except Exception as e:
-        eprint(f"LINE: 背景訊息處理任務發生錯誤: {e}")
-        import traceback
-        eprint(traceback.format_exc())
-        add_log("ERROR", error=str(e), context=f"LINE message processing for {user_id} in {chat_id}")
-
-# ====== Status Check ======
 @app.route('/status', methods=['GET'])
 def status():
     return {
@@ -438,6 +67,5 @@ def main():
     app.run(host='0.0.0.0', port=5190, debug=False)
 
 
-# ====== Main ======
 if __name__ == '__main__':
     main()

--- a/tests/gateways/test_webhook_server.py
+++ b/tests/gateways/test_webhook_server.py
@@ -1,0 +1,37 @@
+from ian.gateways import facebook_webhook, line_webhook, messaging_common, webhook_server
+from ian.config import MEMBER_MAPPING_FILE
+
+
+def test_webhook_post_delegates_facebook_messages(monkeypatch):
+    calls = []
+
+    def fake_handle_facebook_messages(data):
+        calls.append(data)
+
+    monkeypatch.setattr(facebook_webhook, "handle_facebook_messages", fake_handle_facebook_messages)
+
+    client = webhook_server.app.test_client()
+    response = client.post("/", json={"object": "page", "entry": []})
+
+    assert response.status_code == 200
+    assert response.text == "ok"
+    assert calls == [{"object": "page", "entry": []}]
+
+
+def test_webhook_routes_use_split_gateway_modules():
+    assert hasattr(facebook_webhook, "handle_facebook_messages")
+    assert hasattr(line_webhook, "line_handler")
+    assert hasattr(line_webhook, "handle_line_message")
+    assert hasattr(messaging_common, "get_current_time")
+    assert hasattr(messaging_common, "save_chat_history")
+
+
+def test_gateway_helpers_avoid_unneeded_public_wrappers():
+    assert not hasattr(messaging_common, "ensure_upload_dir")
+    assert not hasattr(messaging_common, "run_async_in_thread")
+
+
+def test_facebook_member_mapping_path_comes_from_config():
+    assert facebook_webhook.MAPPING_FILE_PATH == MEMBER_MAPPING_FILE
+    assert MEMBER_MAPPING_FILE.name == "member_mapping.csv"
+    assert MEMBER_MAPPING_FILE.parent.name == "data"


### PR DESCRIPTION
## Summary

Split the FB/LINE webhook gateway into focused modules while keeping the existing `ian webhook` CLI entrypoint and Flask routes intact. `webhook_server.py` now handles route wiring and delegates platform behavior to dedicated adapters.

## Related Issue

Fixes #37

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Configuration or deployment
- [x] Tests

## Changes

- Moved Facebook Messenger webhook dispatch, API helpers, dedupe state, and background task handling into `ian.gateways.facebook_webhook`.
- Moved LINE callback registration, message handling, reply chunking, and LINE profile helpers into `ian.gateways.line_webhook`.
- Added `ian.gateways.messaging_common` for shared Taipei time, upload directory setup, async thread runner, and chat history persistence.
- Updated `ARCHITECTURE.md` and added gateway tests for route delegation and split module boundaries.

## Testing

- [x] Local tests or checks pass
- [ ] Manual verification completed
- [ ] Not tested; reason:

Commands run:

```bash
uv run pytest tests/gateways/test_webhook_server.py
uv run pytest
make precommit
```

## Impact Checklist

- [ ] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [x] Webhook behavior checked, if affected
- [ ] Docker or compose changes checked, if affected
- [x] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

## Notes for Reviewers

This is intended as a behavior-preserving split. Existing Flask endpoints remain `/`, `/line/callback`, and `/status`; `ian.gateways.webhook_server:main` remains the CLI target. The LINE SDK deprecation warnings already existed and are not addressed in this refactor.