### PR TITLE
[Bug]: migrate deprecated LangGraph agent factory import

### DIFF
--- a/src/ian/services/agent/runtime.py
+++ b/src/ian/services/agent/runtime.py
@@ -6,10 +6,10 @@ from concurrent.futures import Future
 from datetime import datetime, timedelta, timezone
 from queue import Queue
 
+from langchain.agents import create_agent
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langgraph.checkpoint.memory import MemorySaver
-from langgraph.prebuilt import create_react_agent
 
 from ian.config import GOOGLE_API_KEY
 from ian.domain.injection import INJECTION_REJECTION_MSG, detect_prompt_injection
@@ -116,10 +116,10 @@ async def run_agentic_workflow():
                 # Initialize or re-initialize agent if needed
                 if session.get("agent") is None:
                     memory = MemorySaver()
-                    agent = create_react_agent(
+                    agent = create_agent(
                         model=llm,
                         tools=tools,
-                        prompt=SYS_PROMPT,
+                        system_prompt=SYS_PROMPT,
                         checkpointer=memory,
                     )
                     set_session_agent(session_id, agent, memory)
@@ -174,10 +174,10 @@ async def run_agentic_workflow():
                             client = MultiServerMCPClient(mcp_config)
                             tools = await client.get_tools()
                         memory = MemorySaver()
-                        new_agent = create_react_agent(
+                        new_agent = create_agent(
                             model=llm,
                             tools=tools,
-                            prompt=SYS_PROMPT,
+                            system_prompt=SYS_PROMPT,
                             checkpointer=memory,
                         )
                         with sessions_lock:

--- a/tests/services/test_agent_package.py
+++ b/tests/services/test_agent_package.py
@@ -35,3 +35,11 @@ def test_agent_runtime_has_prompt_and_session_modules():
     assert "sessions =" not in runtime_source
     assert "from ian.services.agent.prompt import SYS_PROMPT" in runtime_source
     assert "from ian.services.agent.sessions import" in runtime_source
+
+
+def test_agent_runtime_uses_langchain_agent_factory():
+    runtime_source = Path("src/ian/services/agent/runtime.py").read_text()
+
+    assert "from langgraph.prebuilt" not in runtime_source
+    assert "create_react_agent" not in runtime_source
+    assert "from langchain.agents import create_agent" in runtime_source


### PR DESCRIPTION
## Summary

Migrates the agent runtime from the deprecated LangGraph `create_react_agent` factory to LangChain's `create_agent` factory. Updates agent construction to use the supported `system_prompt` argument and adds a regression test for the import path.

## Related Issue

Fixes #41

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration or deployment
- [x] Tests

## Changes

- Replace `from langgraph.prebuilt import create_react_agent` with `from langchain.agents import create_agent`.
- Update both runtime agent factory calls from `prompt=SYS_PROMPT` to `system_prompt=SYS_PROMPT`.
- Add a service-level regression test that blocks the deprecated LangGraph import and `create_react_agent` symbol.

## Testing

- [x] Local tests or checks pass
- [x] Manual verification completed
- [ ] Not tested; reason:

Commands run:

```shell
uv run pytest tests/services/test_agent_package.py
make test
make precommit
```

Manual verification:

```shell
uv run python - <<'PY'
from langchain.agents import create_agent
import inspect
print(create_agent.__module__)
print('system_prompt' in inspect.signature(create_agent).parameters)
print('checkpointer' in inspect.signature(create_agent).parameters)
PY
```

## Impact Checklist

- [ ] Discord bot behavior checked, if affected
- [x] MCP server behavior checked, if affected
- [ ] Webhook behavior checked, if affected
- [x] Docker or compose changes checked, if affected
- [x] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

Discord bot/webhook/manual runtime behavior was not affected directly by this import-only agent factory migration. MCP behavior was covered by the existing test suite; no Docker, compose, or environment variable changes were made.

## Notes for Reviewers

`make test` still reports unrelated existing deprecation warnings from LINE SDK, `jieba/pkg_resources`, and `langchain_community.vectorstores.FAISS`.