### PR TITLE
[Refactor]: centralize stderr eprint helper

### DIFF
--- a/src/ian/gateways/facebook_webhook.py
+++ b/src/ian/gateways/facebook_webhook.py
@@ -7,7 +7,6 @@ import requests
 
 from ian.config import MEMBER_MAPPING_FILE, PAGE_ACCESS_TOKEN
 from ian.gateways.messaging_common import (
-    eprint,
     get_current_time,
     save_chat_history,
 )
@@ -16,6 +15,7 @@ from ian.services.member_store import (
     get_member_name as get_member_name_from_db,
     get_member_role as get_member_role_from_db,
 )
+from ian.utils.console import eprint
 
 MAPPING_FILE_PATH = MEMBER_MAPPING_FILE
 

--- a/src/ian/gateways/line_webhook.py
+++ b/src/ian/gateways/line_webhook.py
@@ -7,7 +7,6 @@ from linebot.models import MessageEvent, TextMessage, TextSendMessage
 
 from ian.config import LINE_ALLOWED_GROUPS, LINE_CHANNEL_ACCESS_TOKEN, LINE_CHANNEL_SECRET
 from ian.gateways.messaging_common import (
-    eprint,
     get_current_time,
     save_chat_history,
 )
@@ -21,6 +20,7 @@ from ian.services.member_store import (
     get_member_name as get_member_name_from_db,
     get_member_role as get_member_role_from_db,
 )
+from ian.utils.console import eprint
 
 line_bot_api = LineBotApi(LINE_CHANNEL_ACCESS_TOKEN)
 line_handler = WebhookHandler(LINE_CHANNEL_SECRET)

--- a/src/ian/gateways/mcp_server.py
+++ b/src/ian/gateways/mcp_server.py
@@ -1,10 +1,10 @@
 import warnings
 
 import asyncio
-import sys
 from typing import Optional, Tuple
 
 import pandas as pd
+from mcp.server.fastmcp import FastMCP
 
 from ian.config import (
     ALLOWED_CHANNELS,
@@ -25,14 +25,9 @@ from ian.services.member_store import (
     update_personal_prompt as _update_personal_prompt,
     update_subscribe as _update_subscribe,
 )
-from mcp.server.fastmcp import FastMCP
+from ian.utils.console import eprint
 
 warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
-
-
-def eprint(*args, **kwargs):
-    """Print to stderr to avoid interfering with MCP stdio transport."""
-    print(*args, file=sys.stderr, **kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/src/ian/gateways/messaging_common.py
+++ b/src/ian/gateways/messaging_common.py
@@ -1,15 +1,9 @@
 import json
 import os
-import sys
 from datetime import datetime, timedelta, timezone
 
 UPLOAD_DIR = "uploads"
 CHAT_HISTORY_FILE = os.path.join(UPLOAD_DIR, "chat_history.json")
-
-
-def eprint(*args, **kwargs):
-    """Print to stderr."""
-    print(*args, file=sys.stderr, **kwargs)
 
 
 def get_current_time():

--- a/src/ian/gateways/webhook_server.py
+++ b/src/ian/gateways/webhook_server.py
@@ -3,8 +3,9 @@ from linebot.exceptions import InvalidSignatureError
 
 from ian.config import FB_VERIFY_TOKEN
 from ian.gateways import facebook_webhook, line_webhook
-from ian.gateways.messaging_common import eprint, get_current_time
+from ian.gateways.messaging_common import get_current_time
 from ian.services.member_store import init as init_member_db
+from ian.utils.console import eprint
 
 app = Flask(__name__)
 

--- a/src/ian/services/agent/logging.py
+++ b/src/ian/services/agent/logging.py
@@ -1,4 +1,3 @@
-import sys
 import threading
 import time
 from datetime import datetime, timedelta, timezone
@@ -7,15 +6,11 @@ from queue import Queue
 import requests
 
 from ian.config import DISCORD_BOT_TOKEN, DISCORD_LOG_CHANNEL_ID_INT
+from ian.utils.console import eprint
 
 LOG_CHANNEL_ID = DISCORD_LOG_CHANNEL_ID_INT
 log_queue: Queue = Queue()
 log_processor_started = False
-
-
-def eprint(*args, **kwargs):
-    """Print to stderr."""
-    print(*args, file=sys.stderr, **kwargs)
 
 
 def start_log_processor():

--- a/src/ian/services/course_catalog.py
+++ b/src/ian/services/course_catalog.py
@@ -1,6 +1,5 @@
 import io
 import os
-import sys
 import time
 from datetime import datetime, timedelta
 from typing import Tuple
@@ -16,10 +15,7 @@ from ian.domain.courses import (
     normalize_date,
     parse_dates_from_query,
 )
-
-
-def eprint(*args, **kwargs):
-    print(*args, file=sys.stderr, **kwargs)
+from ian.utils.console import eprint
 
 
 course_data = None

--- a/src/ian/services/member_store.py
+++ b/src/ian/services/member_store.py
@@ -1,10 +1,10 @@
 import json
-import sys
 import threading
 import time
-import requests
 from datetime import datetime, timedelta
 from typing import Optional
+
+import requests
 
 from ian.config import MEMBER_API_KEY, MEMBER_API_URL, MEMBER_DB_FILE, TZ_TPE
 from ian.domain.members import (
@@ -16,9 +16,8 @@ from ian.domain.members import (
     is_valid_member,
     normalize_email,
 )
+from ian.utils.console import eprint
 
-def eprint(*args, **kwargs):
-    print(*args, file=sys.stderr, **kwargs)
 
 # ---------------------------------------------------------------------------
 # Configuration

--- a/src/ian/services/notifications.py
+++ b/src/ian/services/notifications.py
@@ -1,18 +1,14 @@
-import sys
 import time
 
 import requests
 
 from ian.config import DISCORD_BOT_TOKEN, DISCORD_LOG_CHANNEL_ID
 from ian.domain.reminders import get_valid_bound_members
+from ian.utils.console import eprint
 
 
 LOG_CHANNEL_ID = DISCORD_LOG_CHANNEL_ID
 STAFF_ROLE_KEYWORDS = ("社長", "部長", "部員")
-
-
-def eprint(*args, **kwargs):
-    print(*args, file=sys.stderr, **kwargs)
 
 
 def send_discord_dm(user_id: str, text: str) -> bool:

--- a/src/ian/services/rag.py
+++ b/src/ian/services/rag.py
@@ -3,7 +3,6 @@ import json
 import math
 import os
 import re
-import sys
 from collections import Counter
 from functools import lru_cache
 from typing import Any, Dict, List, Tuple
@@ -16,10 +15,7 @@ from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 from ian.config import CACHE_DIR, DATA_DIR
-
-
-def eprint(*args, **kwargs):
-    print(*args, file=sys.stderr, **kwargs)
+from ian.utils.console import eprint
 
 
 vector_store = None

--- a/src/ian/services/reminder_runner.py
+++ b/src/ian/services/reminder_runner.py
@@ -1,6 +1,5 @@
 import json
 import io
-import sys
 import time
 from datetime import datetime, timedelta, timezone
 from urllib.parse import quote
@@ -16,14 +15,12 @@ from ian.domain.reminders import (
     seconds_until_next_run,
 )
 from ian.services.notifications import send_discord_dm, send_log
+from ian.utils.console import eprint
 
 TZ_TPE = timezone(timedelta(hours=8))
 
 REMINDER_HOUR = 19
 REMINDER_MINUTE = 0
-
-def eprint(*args, **kwargs):
-    print(*args, file=sys.stderr, **kwargs)
 
 
 def load_members() -> list[dict]:

--- a/src/ian/utils/__init__.py
+++ b/src/ian/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Shared low-level utilities."""

--- a/src/ian/utils/console.py
+++ b/src/ian/utils/console.py
@@ -1,0 +1,6 @@
+import sys
+
+
+def eprint(*args, **kwargs):
+    """Print to stderr."""
+    print(*args, file=sys.stderr, **kwargs)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,30 @@
+import ast
+from pathlib import Path
+
+from ian.utils.console import eprint
+
+
+def test_eprint_writes_to_stderr(capsys):
+    eprint("hello", "stderr")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "hello stderr\n"
+
+
+def test_modules_use_shared_eprint_helper():
+    source_root = Path("src/ian")
+    local_eprint_defs = []
+
+    for source_file in source_root.rglob("*.py"):
+        if source_file == source_root / "utils" / "console.py":
+            continue
+
+        tree = ast.parse(source_file.read_text(encoding="utf-8"))
+        if any(
+            isinstance(node, ast.FunctionDef) and node.name == "eprint"
+            for node in ast.walk(tree)
+        ):
+            local_eprint_defs.append(str(source_file))
+
+    assert local_eprint_defs == []


### PR DESCRIPTION
## Summary

Centralizes the duplicated stderr `eprint` helper into `ian.utils.console` and updates services/gateways to import it directly. Keeps Discord log queue behavior separate from the low-level console helper.

## Related Issue

Closes #43

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Configuration or deployment
- [x] Tests

## Changes

- Add `ian.utils.console.eprint` as the shared stderr helper.
- Replace duplicated local `def eprint` definitions across services and gateways with imports from the shared helper.
- Update webhook modules to import `eprint` directly instead of re-exporting it through `messaging_common`.
- Add tests for stderr behavior and to prevent local `eprint` definitions from returning.

## Testing

- [x] Local tests or checks pass
- [x] Manual verification completed
- [ ] Not tested; reason:

Commands run:

```shell
uv run pytest tests/test_console.py
uv run pytest tests/test_console.py tests/gateways/test_webhook_server.py tests/services/test_agent_package.py
make test
make precommit
```

Manual verification:

```shell
rg "^import sys|^def eprint|from ian\.utils\.console import eprint" -n src/ian
```

## Impact Checklist

- [ ] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [x] Webhook behavior checked, if affected
- [x] Docker or compose changes checked, if affected
- [x] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

Webhook imports were covered by existing webhook tests. MCP, Docker/compose, and environment behavior were not changed.

## Notes for Reviewers

`make test` still reports existing unrelated deprecation warnings from LINE SDK, `jieba/pkg_resources`, and `langchain_community.vectorstores.FAISS`.