### PR TITLE
[Test]: add skipped integration placeholders

### DIFF
--- a/tests/integration/test_integration_placeholder.py
+++ b/tests/integration/test_integration_placeholder.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytest.skip(
+    "External integration tests are intentionally deferred. Future coverage "
+    "should exercise MCP runtime wiring, Discord/LINE/Facebook gateways, "
+    "Google Sheets or Apps Script integrations, and live LLM flows without "
+    "requiring secrets in the default CI suite.",
+    allow_module_level=True,
+)

--- a/tests/test_test_structure.py
+++ b/tests/test_test_structure.py
@@ -1,0 +1,27 @@
+import ast
+from pathlib import Path
+
+
+def test_integration_placeholder_exists_and_is_module_skipped():
+    placeholder = Path("tests/integration/test_integration_placeholder.py")
+
+    assert placeholder.exists()
+
+    tree = ast.parse(placeholder.read_text(encoding="utf-8"))
+    skip_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "skip"
+    ]
+
+    assert any(
+        any(
+            keyword.arg == "allow_module_level"
+            and isinstance(keyword.value, ast.Constant)
+            and keyword.value.value is True
+            for keyword in call.keywords
+        )
+        for call in skip_calls
+    )


### PR DESCRIPTION
## Summary

Adds the missing `tests/integration/` skipped placeholder for future MCP and external platform integration tests. Also adds a lightweight structure test so the integration placeholder remains present and module-skipped.

## Related Issue

Closes #21

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration or deployment
- [x] Tests

## Changes

- Add `tests/integration/test_integration_placeholder.py` with module-level `pytest.skip(..., allow_module_level=True)`.
- Document future integration coverage for MCP runtime, Discord/LINE/Facebook gateways, Google integrations, and live LLM flows.
- Add `tests/test_test_structure.py` to assert the integration placeholder exists and remains module-skipped.

## Testing

- [x] Local tests or checks pass
- [x] Manual verification completed
- [ ] Not tested; reason:

Commands run:

```shell
uv run pytest tests/test_test_structure.py
uv run pytest tests/test_test_structure.py tests/agent/test_agent_placeholder.py tests/integration/test_integration_placeholder.py
make test
make precommit
```

## Impact Checklist

- [ ] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [ ] Webhook behavior checked, if affected
- [x] Docker or compose changes checked, if affected
- [x] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

No runtime, Docker, compose, or environment behavior changed. This only adds skipped test placeholders and metadata coverage.

## Notes for Reviewers

`make test` reports 40 passed and 2 skipped locally. Existing unrelated deprecation warnings remain from LINE SDK, `jieba/pkg_resources`, and `langchain_community.vectorstores.FAISS`.