### PR TITLE
[Test]: document pytest baseline structure

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,7 +53,8 @@ ntuai-watson-agent/
 ├── tests/
 │   ├── domain/             # 純邏輯 pytest 覆蓋
 │   ├── services/           # service 邊界 pytest 覆蓋
-│   └── agent/              # Agent/MCP/LLM 整合測試 placeholder（目前 intentionally skipped）
+│   ├── agent/              # Agent runtime placeholder（目前 intentionally skipped）
+│   └── integration/        # MCP/LLM/平台整合測試 placeholder（目前 intentionally skipped）
 ├── start.sh                # 容器啟動腳本（依序啟動各服務）
 ├── Dockerfile              # NVIDIA CUDA 12.1 + Python 3.11 映像
 ├── docker-compose.yml      # 含 GPU 支援與 ngrok tunnel

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -15,7 +15,7 @@
 - `src/ian/domain/`：無 I/O 的純邏輯，例如 prompt injection、URL、課程與社員判斷。
 - `src/ian/services/`：有狀態或外部 I/O 的服務，例如 RAG、member store、agent runtime、通知。
 - `src/ian/gateways/`：平台 adapter，例如 Discord、FB/LINE webhook、MCP server。
-- `tests/`：pytest 測試，依 domain、services、agent 分類。
+- `tests/`：pytest 測試，依 domain、services、agent、integration 分類；agent / integration 目前保留 skipped placeholders，避免預設測試依賴 LLM、MCP、平台 token 或外部服務。
 
 修改時請維持既有分層：純邏輯放在 `domain`，外部服務或狀態邊界放在 `services`，平台入口放在 `gateways`。
 

--- a/tests/test_test_structure.py
+++ b/tests/test_test_structure.py
@@ -2,6 +2,20 @@ import ast
 from pathlib import Path
 
 
+def test_pytest_baseline_is_configured():
+    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+
+    assert '"pytest"' in pyproject
+    assert "[tool.pytest.ini_options]" in pyproject
+    assert 'pythonpath = ["src"]' in pyproject
+    assert 'testpaths = ["tests"]' in pyproject
+
+
+def test_expected_test_directories_exist():
+    for directory in ["domain", "services", "agent", "integration"]:
+        assert Path("tests", directory).is_dir()
+
+
 def test_integration_placeholder_exists_and_is_module_skipped():
     placeholder = Path("tests/integration/test_integration_placeholder.py")
 
@@ -25,3 +39,15 @@ def test_integration_placeholder_exists_and_is_module_skipped():
         )
         for call in skip_calls
     )
+
+
+def test_contribution_docs_describe_test_baseline():
+    contribution = Path("CONTRIBUTION.md").read_text(encoding="utf-8")
+    architecture = Path("ARCHITECTURE.md").read_text(encoding="utf-8")
+
+    assert "make test" in contribution
+    assert "domain" in contribution
+    assert "services" in contribution
+    assert "agent" in contribution
+    assert "integration" in contribution
+    assert "integration" in architecture


### PR DESCRIPTION
## Summary

Completes the pytest baseline issue by making the expected test structure and pytest configuration explicit in tests and documentation. Updates docs to include the integration placeholder directory introduced by the testing roadmap.

## Related Issue

Closes #15

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Configuration or deployment
- [x] Tests

## Changes

- Add structure tests for pytest dependency/config and expected test directories.
- Add docs coverage checks for `make test` and test layout documentation.
- Update `CONTRIBUTION.md` and `ARCHITECTURE.md` to list domain, services, agent, and integration test areas.

## Testing

- [x] Local tests or checks pass
- [x] Manual verification completed
- [ ] Not tested; reason:

Commands run:

```shell
uv run pytest tests/test_test_structure.py
make test
make precommit
```

## Impact Checklist

- [ ] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [ ] Webhook behavior checked, if affected
- [x] Docker or compose changes checked, if affected
- [x] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

No runtime, Docker, compose, or environment behavior changed. This only updates test structure checks and documentation.

## Notes for Reviewers

`make test` reports 47 passed and 2 skipped locally. Existing unrelated deprecation warnings remain from LINE SDK, `jieba/pkg_resources`, and `langchain_community.vectorstores.FAISS`.