### PR TITLE
[Bug]: fix issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,7 +3,6 @@ description: Report a reproducible bug or unexpected behavior.
 title: "[Bug]: "
 labels:
   - bug
-  - triage
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,8 +2,7 @@ name: Feature Request
 description: Suggest an improvement or new capability.
 title: "[Feature]: "
 labels:
-  - enhancement
-  - triage
+  - feature
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

Updates issue templates to reference labels that actually exist in this repository. Feature requests now use `feature`, and bug reports no longer reference the missing `triage` label.

## Related Issue

Closes #55

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration or deployment
- [ ] Tests

## Changes

- Replace `enhancement` with `feature` in `.github/ISSUE_TEMPLATE/feature_request.yml`.
- Remove missing `triage` label from feature and bug issue templates.
- Keep the issue form fields unchanged.

## Testing

- [x] Local tests or checks pass
- [x] Manual verification completed
- [ ] Not tested; reason:

Commands run:

```shell
make precommit
rg "enhancement|triage" -n .github/ISSUE_TEMPLATE .github/PULL_REQUEST_TEMPLATE.md CONTRIBUTION.md
```

Manual verification:

```shell
gh label list --limit 100
```

## Impact Checklist

- [ ] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [ ] Webhook behavior checked, if affected
- [ ] Docker or compose changes checked, if affected
- [x] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

No runtime, Docker, compose, or environment behavior changed. This only updates GitHub issue template metadata.

## Notes for Reviewers

Repository labels currently include `bug`, `feature`, `documentation`, `testing`, `roadmap`, and others, but not `enhancement` or `triage`.