### PR TITLE
[Refactor]: remove duplicated URL validation wrappers

### DIFF
--- a/src/ian/services/agent/prompt.py
+++ b/src/ian/services/agent/prompt.py
@@ -1,9 +1,3 @@
-from ian.domain.urls import (
-    URL_PATTERN,
-    validate_urls_in_response as _validate_urls_in_response,
-)
-
-
 SYS_PROMPT = """
 你叫 Ian，是 "國立臺灣大學 人工智慧應用社 (NTU AI Club)" 的 AI Avatar，負責回答與 NTUAI 社相關的問題（例如：社課時間、社費、活動介紹、參加資格等），
 回答前請依照以下準則：
@@ -99,15 +93,3 @@ SYS_PROMPT = """
   - 如果你覺得完全不需要任何回應，就只回覆 [NO_RESPONSE]
 這樣可以避免不必要的回覆，打擾使用者或群組中正常的聊天。
 """
-
-_URL_PATTERN = URL_PATTERN
-
-def _extract_urls(text: str) -> set[str]:
-    return set(_URL_PATTERN.findall(text))
-
-# 啟動時自動從 SYS_PROMPT 提取已知合法 URL
-_PROMPT_URLS = _extract_urls(SYS_PROMPT)
-
-def validate_urls_in_response(response: str, tool_results: list[str]) -> str:
-    """檢查回覆中的 URL 是否來自合法來源"""
-    return _validate_urls_in_response(response, tool_results, prompt_text=SYS_PROMPT)

--- a/src/ian/services/agent/runtime.py
+++ b/src/ian/services/agent/runtime.py
@@ -13,12 +13,13 @@ from langgraph.checkpoint.memory import MemorySaver
 
 from ian.config import GOOGLE_API_KEY
 from ian.domain.injection import INJECTION_REJECTION_MSG, detect_prompt_injection
+from ian.domain.urls import URL_PLACEHOLDER, validate_urls_in_response
 from ian.services.agent.callbacks import (
     DiscordLogCallbackHandler,
     extract_text_from_output,
 )
 from ian.services.agent.logging import add_log, eprint, start_log_processor
-from ian.services.agent.prompt import SYS_PROMPT, validate_urls_in_response
+from ian.services.agent.prompt import SYS_PROMPT
 from ian.services.agent.sessions import (
     clear_session_if_timeout,
     get_session_agent_and_channel,
@@ -36,6 +37,10 @@ def _unwrap_exception(exc: BaseException) -> BaseException:
     if isinstance(exc, BaseExceptionGroup) and len(exc.exceptions) == 1:
         return _unwrap_exception(exc.exceptions[0])
     return exc
+
+
+def _validate_agent_response_urls(response: str, tool_results: list[str]) -> str:
+    return validate_urls_in_response(response, tool_results, prompt_text=SYS_PROMPT)
 
 
 loop_agent = None
@@ -156,7 +161,7 @@ async def run_agentic_workflow():
 
                 MAX_URL_RETRIES = 2  # 最多嘗試次數（含首次）
                 MAX_INVOKE_RETRIES = 3  # ainvoke 失敗時最多重試次數（含首次）
-                FAKE_URL_PLACEHOLDER = "(連結讀取錯誤，請重新索取)"
+                FAKE_URL_PLACEHOLDER = URL_PLACEHOLDER
 
                 agent_msg = None
                 last_invoke_error = None
@@ -234,7 +239,7 @@ async def run_agentic_workflow():
                             for msg in messages:
                                 if hasattr(msg, 'type') and msg.type == 'tool':
                                     all_tool_texts.append(extract_text_from_output(msg))
-                            parsed_agent_response = validate_urls_in_response(
+                            parsed_agent_response = _validate_agent_response_urls(
                                 parsed_agent_response, all_tool_texts
                             )
 

--- a/tests/services/test_agent_url_validation.py
+++ b/tests/services/test_agent_url_validation.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from ian.domain.urls import URL_PLACEHOLDER
+from ian.services.agent.runtime import _validate_agent_response_urls
+
+
+def test_agent_runtime_allows_prompt_and_tool_result_urls():
+    response = (
+        "社員申請看 https://bit.ly/ntuai-1142-member ，"
+        "講義看 https://docs.example/slides 。"
+    )
+
+    cleaned = _validate_agent_response_urls(
+        response,
+        tool_results=["講義連結：https://docs.example/slides"],
+    )
+
+    assert "https://bit.ly/ntuai-1142-member" in cleaned
+    assert "https://docs.example/slides" in cleaned
+
+
+def test_agent_runtime_replaces_hallucinated_urls_without_prompt_wrappers():
+    cleaned = _validate_agent_response_urls(
+        "社團網站 https://linktr.ee/ntuai ，假連結 https://fake.example/path",
+        tool_results=[],
+    )
+
+    assert "https://linktr.ee/ntuai" in cleaned
+    assert "https://fake.example/path" not in cleaned
+    assert URL_PLACEHOLDER in cleaned
+
+
+def test_prompt_module_does_not_duplicate_url_extraction_helpers():
+    prompt_source = Path("src/ian/services/agent/prompt.py").read_text()
+
+    assert "URL_PATTERN" not in prompt_source
+    assert "_extract_urls" not in prompt_source
+    assert "_PROMPT_URLS" not in prompt_source


### PR DESCRIPTION
## Summary

Centralizes agent response URL validation on `ian.domain.urls` and keeps `prompt.py` limited to `SYS_PROMPT`. Adds focused coverage for prompt allowlisted URLs, tool-result allowlisted URLs, and hallucinated URL replacement without LangGraph/Gemini/MCP calls.

## Related Issue

Fixes #50

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Configuration or deployment
- [x] Tests

## Changes

- Removed duplicated URL pattern/extraction helpers and cached prompt URL state from `ian.services.agent.prompt`.
- Added an agent runtime URL validation boundary that delegates to `ian.domain.urls` with `SYS_PROMPT` as the prompt allowlist.
- Added service tests for prompt URL allowlisting, tool-result URL allowlisting, hallucinated URL replacement, and keeping URL extraction helpers out of `prompt.py`.

## Testing

- [x] Local tests or checks pass
- [x] Manual verification completed
- [ ] Not tested; reason:

Commands run:

```bash
uv run pytest tests/services/test_agent_url_validation.py -q
uv run pytest tests/domain/test_urls.py -q
make test
make precommit
```

## Impact Checklist

- [ ] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [ ] Webhook behavior checked, if affected
- [ ] Docker or compose changes checked, if affected
- [ ] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

## Notes for Reviewers

No external service calls are required for the new tests; this only changes where agent URL validation delegates from.