### PR TITLE
[Refactor]: centralize platform agent message workflow

### DIFF
--- a/src/ian/gateways/agent_bridge.py
+++ b/src/ian/gateways/agent_bridge.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from ian.gateways.messaging_common import get_current_time
+from ian.services.agent import chat_with_agent, parse_no_response, start_dispatcher
+
+
+@dataclass(frozen=True)
+class AgentMessageResult:
+    text: str
+    should_reply: bool
+    reaction_emoji: str | None = None
+
+
+async def run_agent_message_flow(
+    *,
+    session_id: str,
+    user_name: str,
+    user_message: str,
+    roles: Any,
+    channel_id: str,
+    platform: str,
+    account_id: str,
+    current_time: dict[str, Any] | None = None,
+    start_dispatcher_fn: Callable[[str, dict[str, Any]], Any] = start_dispatcher,
+    chat_with_agent_fn: Callable[..., Awaitable[str]] = chat_with_agent,
+) -> AgentMessageResult:
+    """Run the platform-neutral gateway-to-agent message flow."""
+    time_data = current_time or get_current_time()
+    start_dispatcher_fn(user_name, time_data)
+
+    response = await chat_with_agent_fn(
+        session_id,
+        user_name,
+        user_message,
+        roles,
+        time_data["timestamp"],
+        channel_id,
+        platform=platform,
+        account_id=account_id,
+    )
+    is_no_response, reaction_emoji = parse_no_response(response)
+    return AgentMessageResult(
+        text=response,
+        should_reply=not is_no_response,
+        reaction_emoji=reaction_emoji,
+    )

--- a/src/ian/gateways/discord_bot.py
+++ b/src/ian/gateways/discord_bot.py
@@ -3,16 +3,14 @@ import json
 import discord
 from discord.ext import commands
 from discord import app_commands
-from datetime import datetime, timedelta, timezone
 
 from ian.config import DISCORD_BOT_TOKEN
+from ian.gateways.agent_bridge import run_agent_message_flow
+from ian.gateways.messaging_common import get_current_time
 from ian.services.agent import (
-    start_dispatcher,
     start_log_processor,
     send_startup_notification,
-    chat_with_agent,
     clear_session,
-    parse_no_response,
 )
 from ian.services.member_store import get_member_role as get_member_role_from_db, init as init_member_db
 
@@ -39,14 +37,6 @@ def save_chat_history(sender_id, user_name, user_message, bot_response):
     except Exception as e:
         print(f"Error saving chat history: {e}")
 
-def get_current_time():
-    """回傳台灣時區 (UTC+8) 的時間資訊 dict。"""
-    now = datetime.now(timezone(timedelta(hours=8)))
-    return {
-        "nowdatetime": now.strftime("%Y/%m/%d %H:%M:%S"),
-        "nowday": now.strftime("%A"),
-        "timestamp": now.timestamp()
-    }
 
 # FAQ 按鈕視圖
 class FAQView(discord.ui.View):
@@ -64,25 +54,22 @@ class FAQView(discord.ui.View):
         current_time = get_current_time()
 
         try:
-            start_dispatcher(user.display_name, current_time)
-
-            response = await chat_with_agent(
-                user.name,
-                user.display_name,
-                prompt,
-                roles,
-                current_time["timestamp"],
-                str(interaction.channel_id),
+            agent_result = await run_agent_message_flow(
+                session_id=user.name,
+                user_name=user.display_name,
+                user_message=prompt,
+                roles=roles,
+                current_time=current_time,
+                channel_id=str(interaction.channel_id),
                 platform="Discord",
                 account_id=str(user.id),
             )
-            is_no_response, reaction_emoji = parse_no_response(response)
-            if is_no_response:
+            if not agent_result.should_reply:
                 print("Discord: Agent 決定不回覆此訊息")
-                if reaction_emoji:
-                    await interaction.followup.send(reaction_emoji)
+                if agent_result.reaction_emoji:
+                    await interaction.followup.send(agent_result.reaction_emoji)
                 return
-            await interaction.followup.send(response)
+            await interaction.followup.send(agent_result.text)
 
         except Exception as e:
             await interaction.followup.send("⚠️ Error.")
@@ -151,26 +138,23 @@ async def ask(interaction: discord.Interaction, prompt: str):
     )
 
     try:
-        start_dispatcher(user.display_name, current_time)
-
-        bot_response = await chat_with_agent(
-            user.name,
-            user.display_name,
-            prompt,
-            roles,
-            current_time["timestamp"],
-            str(interaction.channel_id),
+        agent_result = await run_agent_message_flow(
+            session_id=user.name,
+            user_name=user.display_name,
+            user_message=prompt,
+            roles=roles,
+            current_time=current_time,
+            channel_id=str(interaction.channel_id),
             platform="Discord",
             account_id=str(user.id),
         )
-        is_no_response, reaction_emoji = parse_no_response(bot_response)
-        if is_no_response:
+        if not agent_result.should_reply:
             print("Discord: Agent 決定不回覆此訊息")
-            if reaction_emoji:
-                await interaction.followup.send(reaction_emoji)
+            if agent_result.reaction_emoji:
+                await interaction.followup.send(agent_result.reaction_emoji)
             return
-        await interaction.followup.send(bot_response)
-        save_chat_history(user.name, user.display_name, prompt, bot_response)
+        await interaction.followup.send(agent_result.text)
+        save_chat_history(user.name, user.display_name, prompt, agent_result.text)
         print("Message processed successfully")
 
     except Exception as e:

--- a/src/ian/gateways/facebook_webhook.py
+++ b/src/ian/gateways/facebook_webhook.py
@@ -6,11 +6,11 @@ import pandas as pd
 import requests
 
 from ian.config import MEMBER_MAPPING_FILE, PAGE_ACCESS_TOKEN
+from ian.gateways.agent_bridge import run_agent_message_flow
 from ian.gateways.messaging_common import (
     get_current_time,
     save_chat_history,
 )
-from ian.services.agent import chat_with_agent, parse_no_response, start_dispatcher
 from ian.services.member_store import (
     get_member_name as get_member_name_from_db,
     get_member_role as get_member_role_from_db,
@@ -130,13 +130,12 @@ async def process_message_task(sender_id, user_message, mid=None):
         print(f"傳送給 agent 的身分資訊: {roles}")
 
         current_time = get_current_time()
-        start_dispatcher(user_name, current_time)
-        bot_response = await chat_with_agent(
-            sender_id,
-            user_name,
-            user_message,
-            roles,
-            current_time["timestamp"],
+        agent_result = await run_agent_message_flow(
+            session_id=sender_id,
+            user_name=user_name,
+            user_message=user_message,
+            roles=roles,
+            current_time=current_time,
             channel_id="NaN",
             platform="FB",
             account_id=account_id,
@@ -144,15 +143,14 @@ async def process_message_task(sender_id, user_message, mid=None):
 
         await send_typing_indicator(sender_id, "typing_off")
 
-        is_no_response, reaction_emoji = parse_no_response(bot_response)
-        if is_no_response:
+        if not agent_result.should_reply:
             eprint("FB: Agent 決定不回覆此訊息")
-            if reaction_emoji and mid:
-                send_reaction(sender_id, mid, reaction_emoji)
+            if agent_result.reaction_emoji and mid:
+                send_reaction(sender_id, mid, agent_result.reaction_emoji)
             return
 
-        send_message(sender_id, bot_response)
-        save_chat_history(sender_id, user_name, user_message, bot_response, "FB")
+        send_message(sender_id, agent_result.text)
+        save_chat_history(sender_id, user_name, user_message, agent_result.text, "FB")
         print(f"FB 訊息處理完成並已回覆給 {user_name}")
 
     except Exception as e:

--- a/src/ian/gateways/line_webhook.py
+++ b/src/ian/gateways/line_webhook.py
@@ -6,15 +6,13 @@ from linebot import LineBotApi, WebhookHandler
 from linebot.models import MessageEvent, TextMessage, TextSendMessage
 
 from ian.config import LINE_ALLOWED_GROUPS, LINE_CHANNEL_ACCESS_TOKEN, LINE_CHANNEL_SECRET
+from ian.gateways.agent_bridge import run_agent_message_flow
 from ian.gateways.messaging_common import (
     get_current_time,
     save_chat_history,
 )
 from ian.services.agent import (
     add_log,
-    chat_with_agent,
-    parse_no_response,
-    start_dispatcher,
 )
 from ian.services.member_store import (
     get_member_name as get_member_name_from_db,
@@ -96,32 +94,30 @@ async def process_line_message_task(reply_token, user_id, user_message, chat_id,
         eprint(f"LINE: 處理 {user_name} 的訊息：{user_message}")
 
         current_time = get_current_time()
-        start_dispatcher(user_name, current_time)
-        bot_response = await chat_with_agent(
-            user_id,
-            user_name,
-            user_message,
-            roles,
-            current_time["timestamp"],
+        agent_result = await run_agent_message_flow(
+            session_id=user_id,
+            user_name=user_name,
+            user_message=user_message,
+            roles=roles,
+            current_time=current_time,
             channel_id=str(chat_id),
             platform="LINE",
             account_id=user_id,
         )
 
-        is_no_response, _ = parse_no_response(bot_response)
-        if is_no_response:
+        if not agent_result.should_reply:
             eprint("LINE: Agent 決定不回覆此訊息")
             return
 
-        if "已達今日使用上限" in bot_response:
+        if "已達今日使用上限" in agent_result.text:
             eprint("LINE: 使用者已達上限，不回覆")
             return
 
         max_chunk_length = 2000
         text_chunks = []
 
-        if len(bot_response) > max_chunk_length:
-            paragraphs = bot_response.split("\n\n")
+        if len(agent_result.text) > max_chunk_length:
+            paragraphs = agent_result.text.split("\n\n")
             current_chunk = ""
 
             for para in paragraphs:
@@ -135,7 +131,7 @@ async def process_line_message_task(reply_token, user_id, user_message, chat_id,
             if current_chunk:
                 text_chunks.append(current_chunk.strip())
         else:
-            text_chunks = [bot_response]
+            text_chunks = [agent_result.text]
 
         max_messages = 5
         line_messages = []
@@ -154,7 +150,7 @@ async def process_line_message_task(reply_token, user_id, user_message, chat_id,
                 eprint(traceback.format_exc())
                 return
 
-        save_chat_history(user_id, user_name, user_message, bot_response, "LINE")
+        save_chat_history(user_id, user_name, user_message, agent_result.text, "LINE")
         eprint(f"LINE: 訊息處理完成並已回覆給 {user_name}")
 
     except Exception as e:

--- a/tests/gateways/test_agent_bridge.py
+++ b/tests/gateways/test_agent_bridge.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+
+import pytest
+
+from ian.gateways import agent_bridge
+
+
+@pytest.mark.anyio
+async def test_agent_bridge_runs_agent_flow_for_normal_response():
+    calls = []
+
+    def fake_start_dispatcher(user_name, current_time):
+        calls.append(("start", user_name, current_time))
+
+    async def fake_chat_with_agent(
+        session_id,
+        user_name,
+        user_message,
+        roles,
+        timestamp,
+        channel_id,
+        *,
+        platform,
+        account_id,
+    ):
+        calls.append(
+            (
+                "chat",
+                session_id,
+                user_name,
+                user_message,
+                roles,
+                timestamp,
+                channel_id,
+                platform,
+                account_id,
+            )
+        )
+        return "正常回覆"
+
+    result = await agent_bridge.run_agent_message_flow(
+        session_id="session-1",
+        user_name="Ian User",
+        user_message="社課時間？",
+        roles=["社員"],
+        channel_id="channel-1",
+        platform="Discord",
+        account_id="account-1",
+        current_time={"timestamp": 123.0},
+        start_dispatcher_fn=fake_start_dispatcher,
+        chat_with_agent_fn=fake_chat_with_agent,
+    )
+
+    assert result.should_reply is True
+    assert result.text == "正常回覆"
+    assert result.reaction_emoji is None
+    assert calls == [
+        ("start", "Ian User", {"timestamp": 123.0}),
+        (
+            "chat",
+            "session-1",
+            "Ian User",
+            "社課時間？",
+            ["社員"],
+            123.0,
+            "channel-1",
+            "Discord",
+            "account-1",
+        ),
+    ]
+
+
+@pytest.mark.anyio
+async def test_agent_bridge_parses_no_response_with_reaction():
+    async def fake_chat_with_agent(*args, **kwargs):
+        return "[NO_RESPONSE:🙏]"
+
+    result = await agent_bridge.run_agent_message_flow(
+        session_id="session-1",
+        user_name="Ian User",
+        user_message="謝謝",
+        roles="社員",
+        channel_id="channel-1",
+        platform="FB",
+        account_id="account-1",
+        current_time={"timestamp": 456.0},
+        start_dispatcher_fn=lambda *args: None,
+        chat_with_agent_fn=fake_chat_with_agent,
+    )
+
+    assert result.should_reply is False
+    assert result.text == "[NO_RESPONSE:🙏]"
+    assert result.reaction_emoji == "🙏"
+
+
+def test_gateways_delegate_core_agent_invocation_to_bridge():
+    gateway_paths = [
+        "src/ian/gateways/discord_bot.py",
+        "src/ian/gateways/facebook_webhook.py",
+        "src/ian/gateways/line_webhook.py",
+    ]
+
+    for path in gateway_paths:
+        source = Path(path).read_text()
+        assert "run_agent_message_flow" in source
+        assert "chat_with_agent(" not in source
+        assert "parse_no_response(" not in source


### PR DESCRIPTION
## Summary

Adds `ian.gateways.agent_bridge` to centralize the platform-neutral gateway-to-agent message flow. Discord, Facebook, and LINE now resolve platform identity locally, delegate dispatcher/agent/no-response handling to the bridge, then keep platform-specific reply, reaction, chunking, and history behavior in their gateway modules.

## Related Issue

Fixes #48

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Configuration or deployment
- [x] Tests

## Changes

- Added `AgentMessageResult` and `run_agent_message_flow` for shared dispatcher, agent call, and `[NO_RESPONSE]` parsing.
- Updated Discord, Facebook, and LINE gateways to call the shared bridge instead of duplicating agent invocation logic.
- Reused shared gateway time helper in Discord while preserving its existing JSONL history persistence.
- Added focused bridge tests with mocked agent calls for normal response and no-response reaction behavior.

## Testing

- [x] Local tests or checks pass
- [x] Manual verification completed
- [ ] Not tested; reason:

Commands run:

```bash
uv run pytest tests/gateways/test_agent_bridge.py -q
uv run pytest tests/gateways -q
uv run ruff check src/ian/gateways tests/gateways
make test
make precommit
```

## Impact Checklist

- [x] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [x] Webhook behavior checked, if affected
- [ ] Docker or compose changes checked, if affected
- [ ] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

## Notes for Reviewers

No live Discord, Facebook, LINE, MCP, or LLM services are required for the new tests. Platform-specific I/O remains in each gateway module.