### PR TITLE
[Chore]: ignore local cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ Thumbs.db
 
 # Project specific
 uploads/
+cache/
 data/
 *.egg-info/


### PR DESCRIPTION
## Summary

Adds the generated top-level `cache/` directory to `.gitignore` so local service runs do not leave noisy untracked files.

## Related Issue

Fixes #61

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration or deployment
- [ ] Tests
- [x] Chore

## Changes

- Added `cache/` to the project-specific section of `.gitignore`.

## Testing

- [x] Local tests or checks pass
- [x] Manual verification completed
- [ ] Not tested; reason:

Commands run:

```bash
git check-ignore -v cache/
uv run pytest -q
make precommit
```

## Impact Checklist

- [ ] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [ ] Webhook behavior checked, if affected
- [ ] Docker or compose changes checked, if affected
- [x] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

## Notes for Reviewers

No runtime behavior changes. This only ignores generated local cache state.