### PR TITLE
[Chore]: skip CI for non-code-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,32 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths:
+      - src/**
+      - tests/**
+      - pyproject.toml
+      - uv.lock
+      - .python-version
+      - .pre-commit-config.yaml
+      - Makefile
+      - Dockerfile
+      - docker-compose.yml
+      - start.sh
+      - .github/workflows/ci.yml
   push:
     branches: [main]
+    paths:
+      - src/**
+      - tests/**
+      - pyproject.toml
+      - uv.lock
+      - .python-version
+      - .pre-commit-config.yaml
+      - Makefile
+      - Dockerfile
+      - docker-compose.yml
+      - start.sh
+      - .github/workflows/ci.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Restricts the CI workflow triggers to code, dependency/config, workflow, and runtime/deployment files so docs-only or repository-hygiene-only changes do not run CI.

## Related Issue

Fixes #63

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Configuration or deployment
- [ ] Tests

## Changes

- Added `paths` filters to the `pull_request` and `push` triggers in `.github/workflows/ci.yml`.

## Testing

- [x] Local tests or checks pass
- [x] Manual verification completed
- [ ] Not tested; reason:

Commands run:

```bash
make precommit
```

Pytest was not run because this change does not modify runtime application code.

## Impact Checklist

- [ ] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [ ] Webhook behavior checked, if affected
- [ ] Docker or compose changes checked, if affected
- [x] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

## Notes for Reviewers

CI will still run when `src/**`, dependency files, workflow files, or runtime/deployment files change. It will skip changes that only touch docs/markdown or repository hygiene files such as `.gitignore`.