### PR TITLE
[Bug]: make webhook platform option affect routes

### DIFF
--- a/src/ian/cli.py
+++ b/src/ian/cli.py
@@ -17,10 +17,10 @@ def _run_mcp(http: bool = False, host: str = "0.0.0.0", port: int = 5191) -> Non
     entrypoint(http=http, host=host, port=port)
 
 
-def _run_webhook() -> None:
+def _run_webhook(platform: str = "all") -> None:
     from ian.gateways.webhook_server import entrypoint
 
-    entrypoint()
+    entrypoint(platform=platform)
 
 
 def _run_reminder(target_date: str | None = None, dry: bool = False, daemon: bool = False) -> None:
@@ -63,7 +63,7 @@ def webhook(
     ),
 ) -> None:
     """Run the Facebook/LINE webhook server."""
-    _run_webhook()
+    _run_webhook(platform=platform.value)
 
 
 @app.command()

--- a/src/ian/gateways/webhook_server.py
+++ b/src/ian/gateways/webhook_server.py
@@ -10,6 +10,22 @@ from ian.utils.console import eprint
 app = Flask(__name__)
 
 VERIFY_TOKEN = FB_VERIFY_TOKEN
+PLATFORM_ALIASES = {
+    "all": {"Facebook", "LINE"},
+    "fb": {"Facebook"},
+    "line": {"LINE"},
+}
+ENABLED_WEBHOOK_PLATFORMS = PLATFORM_ALIASES["all"].copy()
+
+
+def configure_platforms(platform: str = "all") -> set[str]:
+    selected = PLATFORM_ALIASES.get(platform)
+    if selected is None:
+        raise ValueError(f"Unsupported webhook platform: {platform}")
+
+    global ENABLED_WEBHOOK_PLATFORMS
+    ENABLED_WEBHOOK_PLATFORMS = selected.copy()
+    return ENABLED_WEBHOOK_PLATFORMS
 
 # Initialize member database
 try:
@@ -21,6 +37,8 @@ except Exception as e:
 
 @app.route('/', methods=['GET'])
 async def verify():
+    if "Facebook" not in ENABLED_WEBHOOK_PLATFORMS:
+        abort(404)
     if request.args.get("hub.mode") == "subscribe" and request.args.get("hub.challenge"):
         if request.args.get("hub.verify_token") == VERIFY_TOKEN:
             return request.args["hub.challenge"], 200
@@ -29,6 +47,8 @@ async def verify():
 
 @app.route('/', methods=['POST'])
 async def webhook():
+    if "Facebook" not in ENABLED_WEBHOOK_PLATFORMS:
+        abort(404)
     data = request.get_json()
     try:
         if data.get('object') == 'page':
@@ -41,6 +61,9 @@ async def webhook():
 @app.route('/line/callback', methods=['POST'])
 def line_callback():
     """LINE webhook 接收端點。"""
+    if "LINE" not in ENABLED_WEBHOOK_PLATFORMS:
+        abort(404)
+
     signature = request.headers.get("X-Line-Signature", "")
     body = request.get_data(as_text=True)
 
@@ -60,9 +83,10 @@ def status():
     return {
         "status": "running",
         "timestamp": get_current_time()["nowdatetime"],
-        "platforms": ["Facebook", "LINE"]
+        "platforms": sorted(ENABLED_WEBHOOK_PLATFORMS)
     }, 200
 
-def entrypoint():
-    print("啟動 Flask 伺服器...")
+def entrypoint(platform: str = "all"):
+    enabled = configure_platforms(platform)
+    print(f"啟動 Flask 伺服器... platforms={', '.join(sorted(enabled))}")
     app.run(host='0.0.0.0', port=5190, debug=False)

--- a/tests/gateways/test_webhook_server.py
+++ b/tests/gateways/test_webhook_server.py
@@ -18,6 +18,61 @@ def test_webhook_post_delegates_facebook_messages(monkeypatch):
     assert calls == [{"object": "page", "entry": []}]
 
 
+def test_facebook_webhook_route_can_be_disabled(monkeypatch):
+    calls = []
+
+    def fake_handle_facebook_messages(data):
+        calls.append(data)
+
+    monkeypatch.setattr(facebook_webhook, "handle_facebook_messages", fake_handle_facebook_messages)
+    webhook_server.configure_platforms("line")
+
+    try:
+        client = webhook_server.app.test_client()
+        response = client.post("/", json={"object": "page", "entry": []})
+
+        assert response.status_code == 404
+        assert calls == []
+    finally:
+        webhook_server.configure_platforms("all")
+
+
+def test_line_webhook_route_can_be_disabled(monkeypatch):
+    calls = []
+
+    def fake_handle(body, signature):
+        calls.append({"body": body, "signature": signature})
+
+    monkeypatch.setattr(line_webhook.line_handler, "handle", fake_handle)
+    webhook_server.configure_platforms("fb")
+
+    try:
+        client = webhook_server.app.test_client()
+        response = client.post(
+            "/line/callback",
+            data="{}",
+            headers={"X-Line-Signature": "signature"},
+        )
+
+        assert response.status_code == 404
+        assert calls == []
+    finally:
+        webhook_server.configure_platforms("all")
+
+
+def test_webhook_status_reports_enabled_platforms():
+    webhook_server.configure_platforms("line")
+
+    try:
+        client = webhook_server.app.test_client()
+        response = client.get("/status")
+
+        assert response.status_code == 200
+        assert response.json["platforms"] == ["LINE"]
+    finally:
+        webhook_server.configure_platforms("all")
+
+
 def test_webhook_routes_use_split_gateway_modules():
     assert hasattr(facebook_webhook, "handle_facebook_messages")
     assert hasattr(line_webhook, "line_handler")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,15 +62,15 @@ def test_serve_command_delegates_to_app(monkeypatch):
 def test_webhook_command_accepts_valid_platform(monkeypatch):
     calls = []
 
-    def fake_main():
-        calls.append("called")
+    def fake_main(platform="all"):
+        calls.append({"platform": platform})
 
     monkeypatch.setattr(cli, "_run_webhook", fake_main)
 
     result = runner.invoke(cli.app, ["webhook", "--platform", "line"])
 
     assert result.exit_code == 0
-    assert calls == ["called"]
+    assert calls == [{"platform": "line"}]
 
 
 def test_webhook_command_rejects_unknown_platform(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes `ian webhook --platform ...` so the selected platform is passed from the CLI into the Flask webhook server and controls which routes are active.

## Related Issue

Fixes #67

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration or deployment
- [x] Tests

## Changes

- Pass `--platform all|fb|line` from `ian.cli` into `webhook_server.entrypoint()`.
- Add platform configuration in `webhook_server` for enabled Facebook/LINE routes.
- Return 404 for disabled platform webhook routes.
- Report enabled platforms from `/status`.
- Add CLI and gateway tests covering platform propagation and route gating.

## Testing

- [x] Local tests or checks pass
- [x] Manual verification completed
- [ ] Not tested; reason:

Commands run:

```bash
uv run pytest tests/test_cli.py::test_webhook_command_accepts_valid_platform tests/gateways/test_webhook_server.py::test_facebook_webhook_route_can_be_disabled tests/gateways/test_webhook_server.py::test_line_webhook_route_can_be_disabled tests/gateways/test_webhook_server.py::test_webhook_status_reports_enabled_platforms -q
uv run pytest tests/test_cli.py tests/gateways/test_webhook_server.py -q
uv run pytest -q
make precommit
```

## Impact Checklist

- [ ] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [x] Webhook behavior checked, if affected
- [ ] Docker or compose changes checked, if affected
- [x] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

## Notes for Reviewers

Default behavior remains `--platform all`, so existing `ian webhook` and `ian serve` startup keeps both Facebook and LINE routes enabled.