### PR TITLE
[Refactor]: extract LINE message chunking helper

### DIFF
--- a/src/ian/domain/messages.py
+++ b/src/ian/domain/messages.py
@@ -1,0 +1,47 @@
+def split_message_chunks(
+    text: str,
+    *,
+    max_length: int = 2000,
+    max_chunks: int = 5,
+) -> list[str]:
+    """Split text into platform-sized chunks, preserving paragraphs when possible."""
+    if max_length <= 0:
+        raise ValueError("max_length must be positive")
+    if max_chunks <= 0:
+        return []
+
+    chunks: list[str] = []
+    current_chunk = ""
+
+    for paragraph in text.split("\n\n"):
+        paragraph = paragraph.strip()
+        if not paragraph:
+            continue
+
+        if len(paragraph) > max_length:
+            if current_chunk:
+                chunks.append(current_chunk.strip())
+                current_chunk = ""
+            chunks.extend(_split_long_paragraph(paragraph, max_length))
+        elif not current_chunk:
+            current_chunk = paragraph
+        elif len(current_chunk) + len(paragraph) + 2 <= max_length:
+            current_chunk += "\n\n" + paragraph
+        else:
+            chunks.append(current_chunk.strip())
+            current_chunk = paragraph
+
+        if len(chunks) >= max_chunks:
+            return chunks[:max_chunks]
+
+    if current_chunk:
+        chunks.append(current_chunk.strip())
+
+    return [chunk for chunk in chunks if chunk.strip()][:max_chunks]
+
+
+def _split_long_paragraph(paragraph: str, max_length: int) -> list[str]:
+    return [
+        paragraph[start : start + max_length]
+        for start in range(0, len(paragraph), max_length)
+    ]

--- a/src/ian/gateways/line_webhook.py
+++ b/src/ian/gateways/line_webhook.py
@@ -6,6 +6,7 @@ from linebot import LineBotApi, WebhookHandler
 from linebot.models import MessageEvent, TextMessage, TextSendMessage
 
 from ian.config import LINE_ALLOWED_GROUPS, LINE_CHANNEL_ACCESS_TOKEN, LINE_CHANNEL_SECRET
+from ian.domain.messages import split_message_chunks
 from ian.gateways.agent_bridge import run_agent_message_flow
 from ian.gateways.messaging_common import (
     get_current_time,
@@ -113,31 +114,10 @@ async def process_line_message_task(reply_token, user_id, user_message, chat_id,
             eprint("LINE: 使用者已達上限，不回覆")
             return
 
-        max_chunk_length = 2000
-        text_chunks = []
-
-        if len(agent_result.text) > max_chunk_length:
-            paragraphs = agent_result.text.split("\n\n")
-            current_chunk = ""
-
-            for para in paragraphs:
-                if len(current_chunk) + len(para) + 2 <= max_chunk_length:
-                    current_chunk += para + "\n\n"
-                else:
-                    if current_chunk:
-                        text_chunks.append(current_chunk.strip())
-                    current_chunk = para + "\n\n"
-
-            if current_chunk:
-                text_chunks.append(current_chunk.strip())
-        else:
-            text_chunks = [agent_result.text]
-
-        max_messages = 5
         line_messages = []
-        for chunk in text_chunks[:max_messages]:
+        for chunk in split_message_chunks(agent_result.text):
             if chunk.strip():
-                line_messages.append(TextSendMessage(text=chunk.strip()))
+                line_messages.append(TextSendMessage(text=chunk))
 
         if line_messages:
             try:

--- a/tests/domain/test_messages.py
+++ b/tests/domain/test_messages.py
@@ -1,0 +1,23 @@
+from ian.domain.messages import split_message_chunks
+
+
+def test_split_message_chunks_returns_short_text_as_single_chunk():
+    assert split_message_chunks("hello") == ["hello"]
+
+
+def test_split_message_chunks_groups_paragraphs_without_exceeding_limit():
+    text = "aaa\n\nbbb\n\ncccc"
+
+    assert split_message_chunks(text, max_length=10) == ["aaa\n\nbbb", "cccc"]
+
+
+def test_split_message_chunks_splits_single_long_paragraph():
+    text = "abcdefghij"
+
+    assert split_message_chunks(text, max_length=4) == ["abcd", "efgh", "ij"]
+
+
+def test_split_message_chunks_limits_max_chunks_and_omits_blank_chunks():
+    text = "one\n\n\n\ntwo\n\nthree\n\nfour"
+
+    assert split_message_chunks(text, max_length=5, max_chunks=2) == ["one", "two"]


### PR DESCRIPTION
## Summary

Extracts LINE response chunking into a pure domain helper and has the LINE gateway convert returned chunks into `TextSendMessage` objects.

## Related Issue

Fixes #51

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Configuration or deployment
- [x] Tests

## Changes

- Added `ian.domain.messages.split_message_chunks` with paragraph-aware splitting.
- Preserved LINE defaults of 2000 characters and at most 5 chunks.
- Removed raw chunking logic from `line_webhook.py`.
- Added deterministic domain tests for short text, paragraph grouping, long paragraphs, and max chunk count.

## Testing

- [x] Local tests or checks pass
- [x] Manual verification completed
- [ ] Not tested; reason:

Commands run:

```bash
uv run pytest tests/domain/test_messages.py -q
uv run pytest tests/domain/test_messages.py tests/gateways/test_webhook_server.py -q
uv run pytest -q
make precommit
```

## Impact Checklist

- [ ] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [x] Webhook behavior checked, if affected
- [ ] Docker or compose changes checked, if affected
- [x] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

## Notes for Reviewers

The helper is pure text logic and does not import LINE SDK APIs. For a single paragraph longer than the max length, it now splits by character window so each returned chunk stays within the configured limit.