### PR TITLE
[Refactor]: deduplicate member lookup with reload

### DIFF
--- a/src/ian/services/member_store.py
+++ b/src/ian/services/member_store.py
@@ -111,12 +111,19 @@ def lookup_member_by_platform(platform: str, account_id: str) -> Optional[dict]:
     return None
 
 
+def _lookup_member_with_reload(platform: str, account_id: str) -> Optional[dict]:
+    """Find a member, reloading local data once if the in-memory cache misses."""
+    member = lookup_member_by_platform(platform, account_id)
+    if member:
+        return member
+
+    load_member_db()
+    return lookup_member_by_platform(platform, account_id)
+
+
 def get_member_name(platform: str, account_id: str) -> Optional[str]:
     """Return the member's name (id field) by platform account ID, or None if not found."""
-    member = lookup_member_by_platform(platform, account_id)
-    if not member:
-        load_member_db()
-        member = lookup_member_by_platform(platform, account_id)
+    member = _lookup_member_with_reload(platform, account_id)
     if member:
         return member.get("id", "").strip() or None
     return None
@@ -131,11 +138,7 @@ def get_member_role(platform: str, account_id: str) -> str:
     If not found in memory, reloads from local file in case another
     process (e.g. MCP server) updated it via bind_email.
     """
-    member = lookup_member_by_platform(platform, account_id)
-    if not member:
-        # Reload from file — another process may have updated it
-        load_member_db()
-        member = lookup_member_by_platform(platform, account_id)
+    member = _lookup_member_with_reload(platform, account_id)
     if not member:
         return "非社員"
     if not is_valid_member(member):
@@ -344,10 +347,7 @@ def update_subscribe(platform: str, account_id: str, subscribe_str: str) -> dict
 
     Returns dict with 'success' (bool) and 'message' (str).
     """
-    member = lookup_member_by_platform(platform, account_id)
-    if not member:
-        load_member_db()
-        member = lookup_member_by_platform(platform, account_id)
+    member = _lookup_member_with_reload(platform, account_id)
     if not member:
         return {"success": False, "message": "找不到您的社員資料，請先透過 Email 綁定身分。"}
 
@@ -407,10 +407,7 @@ def update_personal_prompt(platform: str, account_id: str, prompt_text: str) -> 
 
     Returns dict with 'success' (bool) and 'message' (str).
     """
-    member = lookup_member_by_platform(platform, account_id)
-    if not member:
-        load_member_db()
-        member = lookup_member_by_platform(platform, account_id)
+    member = _lookup_member_with_reload(platform, account_id)
     if not member:
         return {"success": False, "message": "找不到您的社員資料，無法更新個人備註。"}
 

--- a/tests/services/test_member_store_lookup_reload.py
+++ b/tests/services/test_member_store_lookup_reload.py
@@ -1,0 +1,121 @@
+from datetime import datetime, timedelta, timezone
+
+from ian.services import member_store
+
+
+def _valid_member(**overrides):
+    member = {
+        "id": "Alice",
+        "email": "alice@example.com",
+        "Tier": "",
+        "valid_date": (
+            datetime.now(timezone(timedelta(hours=8))) + timedelta(days=1)
+        ).isoformat(),
+        "discord_acc_id": "discord-1",
+        "line_acc_id": "",
+        "fb_acc_id": "",
+        "subscribe": "",
+        "personal_prompt": "",
+    }
+    member.update(overrides)
+    return member
+
+
+def test_lookup_member_with_reload_returns_initial_hit_without_reloading(monkeypatch):
+    calls = []
+
+    def fake_lookup(platform, account_id):
+        calls.append(("lookup", platform, account_id))
+        return _valid_member()
+
+    def fake_load():
+        calls.append(("load",))
+        return True
+
+    monkeypatch.setattr(member_store, "lookup_member_by_platform", fake_lookup)
+    monkeypatch.setattr(member_store, "load_member_db", fake_load)
+
+    member = member_store._lookup_member_with_reload("Discord", "discord-1")
+
+    assert member["id"] == "Alice"
+    assert calls == [("lookup", "Discord", "discord-1")]
+
+
+def test_lookup_member_with_reload_returns_reload_hit(monkeypatch):
+    calls = []
+    lookups = iter([None, _valid_member(id="Bob")])
+
+    def fake_lookup(platform, account_id):
+        calls.append(("lookup", platform, account_id))
+        return next(lookups)
+
+    def fake_load():
+        calls.append(("load",))
+        return True
+
+    monkeypatch.setattr(member_store, "lookup_member_by_platform", fake_lookup)
+    monkeypatch.setattr(member_store, "load_member_db", fake_load)
+
+    member = member_store._lookup_member_with_reload("Discord", "discord-1")
+
+    assert member["id"] == "Bob"
+    assert calls == [
+        ("lookup", "Discord", "discord-1"),
+        ("load",),
+        ("lookup", "Discord", "discord-1"),
+    ]
+
+
+def test_lookup_member_with_reload_returns_none_after_reload_miss(monkeypatch):
+    calls = []
+
+    def fake_lookup(platform, account_id):
+        calls.append(("lookup", platform, account_id))
+        return None
+
+    def fake_load():
+        calls.append(("load",))
+        return True
+
+    monkeypatch.setattr(member_store, "lookup_member_by_platform", fake_lookup)
+    monkeypatch.setattr(member_store, "load_member_db", fake_load)
+
+    assert member_store._lookup_member_with_reload("Discord", "missing") is None
+    assert calls == [
+        ("lookup", "Discord", "missing"),
+        ("load",),
+        ("lookup", "Discord", "missing"),
+    ]
+
+
+def test_get_member_role_uses_reload_helper(monkeypatch):
+    calls = []
+
+    def fake_lookup_with_reload(platform, account_id):
+        calls.append((platform, account_id))
+        return _valid_member(Tier="VIP")
+
+    monkeypatch.setattr(member_store, "_lookup_member_with_reload", fake_lookup_with_reload)
+
+    assert member_store.get_member_role("Discord", "discord-1") == "VIP 社員"
+    assert calls == [("Discord", "discord-1")]
+
+
+def test_update_subscribe_uses_reload_helper(monkeypatch):
+    calls = []
+
+    def fake_lookup_with_reload(platform, account_id):
+        calls.append((platform, account_id))
+        return _valid_member(subscribe="", discord_acc_id="discord-1")
+
+    def fake_update_member_field(email, field, value):
+        return {"success": True, "message": "更新成功"}
+
+    monkeypatch.setattr(member_store, "_lookup_member_with_reload", fake_lookup_with_reload)
+    monkeypatch.setattr(member_store, "_update_member_field", fake_update_member_field)
+
+    result = member_store.update_subscribe("Discord", "discord-1", "discord")
+
+    assert result["success"] is True
+    assert result["message"] == "訂閱設定已更新！您將在以下平台收到每日課程通知：discord"
+    assert calls == [("Discord", "discord-1")]


### PR DESCRIPTION
## Summary
- Add an internal member lookup helper that reloads local member data once on cache miss
- Route member name, role, subscription, and personal prompt updates through the shared helper
- Add focused tests for initial hit, reload hit, reload miss, and caller behavior

Fixes #52

## Testing
- uv run pytest tests/services/test_member_store_lookup_reload.py -q
- uv run pytest tests/services/test_member_store_lookup_reload.py tests/domain/test_members.py -q
- uv run pytest -q
- make precommit