### PR TITLE
[Refactor]: centralize Discord HTTP API client helpers

### DIFF
--- a/src/ian/services/agent/logging.py
+++ b/src/ian/services/agent/logging.py
@@ -3,9 +3,8 @@ import time
 from datetime import datetime, timedelta, timezone
 from queue import Queue
 
-import requests
-
-from ian.config import DISCORD_BOT_TOKEN, DISCORD_LOG_CHANNEL_ID_INT
+from ian.config import DISCORD_LOG_CHANNEL_ID_INT
+from ian.services import discord_api
 from ian.utils.console import eprint
 
 LOG_CHANNEL_ID = DISCORD_LOG_CHANNEL_ID_INT
@@ -42,14 +41,7 @@ def send_startup_notification():
             "```"
         )
 
-        url = f"https://discord.com/api/v10/channels/{LOG_CHANNEL_ID}/messages"
-        headers = {
-            "Authorization": f"Bot {DISCORD_BOT_TOKEN}",
-            "Content-Type": "application/json",
-        }
-        payload = {"content": message}
-
-        response = requests.post(url, headers=headers, json=payload, timeout=10)
+        response = discord_api.send_channel_message(LOG_CHANNEL_ID, message)
         if response.status_code != 200:
             eprint(
                 "Failed to send startup notification: "
@@ -80,14 +72,7 @@ def _send_log_to_discord_sync(log_entry: dict):
         if len(message) > 1900:
             message = message[:1900] + "...(truncated)"
 
-        url = f"https://discord.com/api/v10/channels/{LOG_CHANNEL_ID}/messages"
-        headers = {
-            "Authorization": f"Bot {DISCORD_BOT_TOKEN}",
-            "Content-Type": "application/json",
-        }
-        payload = {"content": message}
-
-        response = requests.post(url, headers=headers, json=payload, timeout=10)
+        response = discord_api.send_channel_message(LOG_CHANNEL_ID, message)
         if response.status_code != 200:
             eprint(f"Failed to send log to Discord: {response.status_code} - {response.text}")
     except Exception as e:

--- a/src/ian/services/discord_api.py
+++ b/src/ian/services/discord_api.py
@@ -1,0 +1,31 @@
+import requests
+
+from ian.config import DISCORD_BOT_TOKEN
+
+
+API_BASE_URL = "https://discord.com/api/v10"
+REQUEST_TIMEOUT = 10
+
+
+def _bot_headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bot {DISCORD_BOT_TOKEN}",
+        "Content-Type": "application/json",
+    }
+
+
+def _post(endpoint: str, payload: dict) -> requests.Response:
+    return requests.post(
+        f"{API_BASE_URL}{endpoint}",
+        headers=_bot_headers(),
+        json=payload,
+        timeout=REQUEST_TIMEOUT,
+    )
+
+
+def create_dm_channel(user_id: str) -> requests.Response:
+    return _post("/users/@me/channels", {"recipient_id": user_id})
+
+
+def send_channel_message(channel_id: str | int, message: str) -> requests.Response:
+    return _post(f"/channels/{channel_id}/messages", {"content": message})

--- a/src/ian/services/notifications.py
+++ b/src/ian/services/notifications.py
@@ -1,9 +1,8 @@
 import time
 
-import requests
-
 from ian.config import DISCORD_BOT_TOKEN, DISCORD_LOG_CHANNEL_ID
 from ian.domain.reminders import get_valid_bound_members
+from ian.services import discord_api
 from ian.utils.console import eprint
 
 
@@ -12,27 +11,13 @@ STAFF_ROLE_KEYWORDS = ("社長", "部長", "部員")
 
 
 def send_discord_dm(user_id: str, text: str) -> bool:
-    headers = {
-        "Authorization": f"Bot {DISCORD_BOT_TOKEN}",
-        "Content-Type": "application/json",
-    }
-    response = requests.post(
-        "https://discord.com/api/v10/users/@me/channels",
-        headers=headers,
-        json={"recipient_id": user_id},
-        timeout=10,
-    )
+    response = discord_api.create_dm_channel(user_id)
     if response.status_code != 200:
         eprint(f"  [Discord] Failed to create DM channel for {user_id}: {response.text}")
         return False
 
     dm_channel_id = response.json()["id"]
-    message_response = requests.post(
-        f"https://discord.com/api/v10/channels/{dm_channel_id}/messages",
-        headers=headers,
-        json={"content": text},
-        timeout=10,
-    )
+    message_response = discord_api.send_channel_message(dm_channel_id, text)
     if message_response.status_code != 200:
         eprint(f"  [Discord] Failed to send message to {user_id}: {message_response.text}")
         return False
@@ -50,12 +35,7 @@ def send_log(message: str):
 
 def send_discord_channel_message(channel_id: str, message: str) -> bool:
     try:
-        url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
-        headers = {
-            "Authorization": f"Bot {DISCORD_BOT_TOKEN}",
-            "Content-Type": "application/json",
-        }
-        response = requests.post(url, headers=headers, json={"content": message}, timeout=10)
+        response = discord_api.send_channel_message(channel_id, message)
         if response.status_code in (200, 201):
             eprint(f"[notify_staff] 成功發送通知到 Discord channel {channel_id}")
             return True

--- a/tests/services/test_discord_api.py
+++ b/tests/services/test_discord_api.py
@@ -1,0 +1,122 @@
+from ian.services import notifications
+from ian.services.agent import logging as agent_logging
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, text="", payload=None):
+        self.status_code = status_code
+        self.text = text
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+def test_create_dm_channel_posts_recipient_with_bot_headers(monkeypatch):
+    from ian.services import discord_api
+
+    calls = []
+
+    def fake_post(url, headers, json, timeout):
+        calls.append({"url": url, "headers": headers, "json": json, "timeout": timeout})
+        return FakeResponse(200, payload={"id": "dm-1"})
+
+    monkeypatch.setattr(discord_api, "DISCORD_BOT_TOKEN", "bot-token")
+    monkeypatch.setattr(discord_api.requests, "post", fake_post)
+
+    response = discord_api.create_dm_channel("user-1")
+
+    assert response.json() == {"id": "dm-1"}
+    assert calls == [
+        {
+            "url": "https://discord.com/api/v10/users/@me/channels",
+            "headers": {
+                "Authorization": "Bot bot-token",
+                "Content-Type": "application/json",
+            },
+            "json": {"recipient_id": "user-1"},
+            "timeout": 10,
+        }
+    ]
+
+
+def test_send_channel_message_posts_content_with_bot_headers(monkeypatch):
+    from ian.services import discord_api
+
+    calls = []
+
+    def fake_post(url, headers, json, timeout):
+        calls.append({"url": url, "headers": headers, "json": json, "timeout": timeout})
+        return FakeResponse(201, payload={"id": "message-1"})
+
+    monkeypatch.setattr(discord_api, "DISCORD_BOT_TOKEN", "bot-token")
+    monkeypatch.setattr(discord_api.requests, "post", fake_post)
+
+    response = discord_api.send_channel_message("channel-1", "hello")
+
+    assert response.status_code == 201
+    assert calls == [
+        {
+            "url": "https://discord.com/api/v10/channels/channel-1/messages",
+            "headers": {
+                "Authorization": "Bot bot-token",
+                "Content-Type": "application/json",
+            },
+            "json": {"content": "hello"},
+            "timeout": 10,
+        }
+    ]
+
+
+def test_send_discord_dm_uses_shared_client_and_preserves_failure_message(
+    monkeypatch, capsys
+):
+    from ian.services import discord_api
+
+    def fake_create_dm_channel(user_id):
+        assert user_id == "user-1"
+        return FakeResponse(500, text="cannot create")
+
+    monkeypatch.setattr(discord_api, "create_dm_channel", fake_create_dm_channel)
+
+    assert notifications.send_discord_dm("user-1", "hello") is False
+
+    captured = capsys.readouterr()
+    assert "Failed to create DM channel for user-1: cannot create" in captured.err
+
+
+def test_send_discord_channel_message_uses_shared_client_for_success(monkeypatch, capsys):
+    from ian.services import discord_api
+
+    calls = []
+
+    def fake_send_channel_message(channel_id, message):
+        calls.append((channel_id, message))
+        return FakeResponse(201, text="created")
+
+    monkeypatch.setattr(discord_api, "send_channel_message", fake_send_channel_message)
+
+    assert notifications.send_discord_channel_message("channel-1", "hello") is True
+    assert calls == [("channel-1", "hello")]
+
+    captured = capsys.readouterr()
+    assert "成功發送通知到 Discord channel channel-1" in captured.err
+
+
+def test_agent_logging_uses_shared_client_for_failure(monkeypatch, capsys):
+    from ian.services import discord_api
+
+    calls = []
+
+    def fake_send_channel_message(channel_id, message):
+        calls.append((channel_id, message))
+        return FakeResponse(500, text="boom")
+
+    monkeypatch.setattr(agent_logging, "LOG_CHANNEL_ID", 123)
+    monkeypatch.setattr(discord_api, "send_channel_message", fake_send_channel_message)
+
+    agent_logging._send_log_to_discord_sync({"type": "INFO", "message": "hello"})
+
+    assert calls == [(123, "```\n[] INFO\n└─ hello\n```")]
+    captured = capsys.readouterr()
+    assert "Failed to send log to Discord: 500 - boom" in captured.err


### PR DESCRIPTION
## Summary
- Add a shared Discord API helper for Bot auth headers, API base URL, POST timeout, DM channel creation, and channel messages
- Route member notifications, staff/log channel messages, and agent Discord logging through the shared helper
- Add mocked tests for helper request construction plus success/failure caller behavior

Fixes #54

## Testing
- uv run pytest tests/services/test_discord_api.py -q
- uv run pytest tests/services/test_discord_api.py tests/services/test_notifications.py -q
- uv run pytest -q
- make precommit