### PR TITLE
[Test]: cover member role and subscription edge cases

### DIFF
--- a/tests/domain/test_members.py
+++ b/tests/domain/test_members.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from ian.domain.members import (
     get_role_from_tier,
     is_valid_member,
@@ -9,27 +11,73 @@ from ian.domain.members import (
 )
 
 
-def test_member_validity_uses_taiwan_time():
-    future = datetime.now(timezone(timedelta(hours=8))) + timedelta(days=1)
-    past = datetime.now(timezone(timedelta(hours=8))) - timedelta(days=1)
-
-    assert is_valid_member({"valid_date": future.isoformat()})
-    assert not is_valid_member({"valid_date": past.isoformat()})
-    assert not is_valid_member({"valid_date": ""})
+TPE = timezone(timedelta(hours=8))
+NOW = datetime(2026, 3, 7, tzinfo=TPE)
 
 
-def test_role_and_platform_mapping_match_legacy_values():
-    assert get_role_from_tier("STAFF") == "幹部"
-    assert get_role_from_tier("VIP") == "VIP 社員"
-    assert get_role_from_tier("") == "社員"
-    assert platform_field("Discord") == "discord_acc_id"
-    assert platform_field("LINE") == "line_acc_id"
+@pytest.mark.parametrize(
+    ("member", "expected"),
+    [
+        ({"valid_date": "2026-03-08T00:00:00+08:00"}, True),
+        ({"valid_date": "2026-03-07T00:00:00+08:00"}, True),
+        ({"valid_date": "2026-03-06T23:59:59+08:00"}, False),
+        ({"valid_date": "2026-03-07T00:00:00Z"}, True),
+        ({"valid_date": ""}, False),
+        ({"valid_date": "not-a-date"}, False),
+        ({"valid_date": None}, False),
+        ({}, False),
+    ],
+)
+def test_member_validity_handles_edge_cases(member, expected):
+    assert is_valid_member(member, now=NOW) is expected
+
+
+@pytest.mark.parametrize(
+    ("tier", "expected"),
+    [
+        ("STAFF", "幹部"),
+        ("VIP", "VIP 社員"),
+        ("", "社員"),
+        ("NORMAL", "NORMAL"),
+    ],
+)
+def test_role_mapping_handles_known_and_custom_tiers(tier, expected):
+    assert get_role_from_tier(tier) == expected
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected"),
+    [
+        ("Discord", "discord_acc_id"),
+        ("FB", "fb_acc_id"),
+        ("LINE", "line_acc_id"),
+        ("Slack", None),
+        ("discord", None),
+        ("", None),
+    ],
+)
+def test_platform_field_mapping_handles_supported_and_unknown_platforms(
+    platform, expected
+):
+    assert platform_field(platform) == expected
 
 
 def test_normalize_email_lowercases_local_part_only():
     assert normalize_email(" USER.Name@Example.COM ") == "user.name@Example.COM"
 
 
-def test_parse_subscribe_platforms_trims_lowercases_and_deduplicates():
-    assert parse_subscribe_platforms(" Discord, discord,  DISCORD ") == ["discord"]
-    assert parse_subscribe_platforms(" ") == []
+@pytest.mark.parametrize(
+    ("subscribe_str", "expected"),
+    [
+        (" Discord, discord,  DISCORD ", ["discord"]),
+        (" ", []),
+        ("", []),
+        (",,,", []),
+        ("discord,line, discord", ["discord", "line"]),
+        ("LINE, discord,fb", ["discord", "fb", "line"]),
+    ],
+)
+def test_parse_subscribe_platforms_trims_lowercases_deduplicates_and_sorts(
+    subscribe_str, expected
+):
+    assert parse_subscribe_platforms(subscribe_str) == expected

--- a/tests/services/test_member_store_lookup_reload.py
+++ b/tests/services/test_member_store_lookup_reload.py
@@ -1,6 +1,13 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from ian.services import member_store
+
+
+TPE = timezone(timedelta(hours=8))
+FUTURE_VALID_DATE = datetime(2099, 1, 1, tzinfo=TPE).isoformat()
+PAST_VALID_DATE = datetime(2000, 1, 1, tzinfo=TPE).isoformat()
 
 
 def _valid_member(**overrides):
@@ -8,9 +15,7 @@ def _valid_member(**overrides):
         "id": "Alice",
         "email": "alice@example.com",
         "Tier": "",
-        "valid_date": (
-            datetime.now(timezone(timedelta(hours=8))) + timedelta(days=1)
-        ).isoformat(),
+        "valid_date": FUTURE_VALID_DATE,
         "discord_acc_id": "discord-1",
         "line_acc_id": "",
         "fb_acc_id": "",
@@ -88,34 +93,121 @@ def test_lookup_member_with_reload_returns_none_after_reload_miss(monkeypatch):
     ]
 
 
-def test_get_member_role_uses_reload_helper(monkeypatch):
+@pytest.mark.parametrize(
+    ("member", "expected_role"),
+    [
+        (None, "非社員"),
+        (_valid_member(Tier="STAFF"), "幹部"),
+        (_valid_member(Tier="VIP"), "VIP 社員"),
+        (_valid_member(Tier=""), "社員"),
+        (
+            _valid_member(valid_date=PAST_VALID_DATE),
+            "非社員（已過期）",
+        ),
+    ],
+)
+def test_get_member_role_handles_member_status_and_tiers(
+    monkeypatch, member, expected_role
+):
     calls = []
 
     def fake_lookup_with_reload(platform, account_id):
         calls.append((platform, account_id))
-        return _valid_member(Tier="VIP")
+        return member
 
     monkeypatch.setattr(member_store, "_lookup_member_with_reload", fake_lookup_with_reload)
 
-    assert member_store.get_member_role("Discord", "discord-1") == "VIP 社員"
+    assert member_store.get_member_role("Discord", "discord-1") == expected_role
     assert calls == [("Discord", "discord-1")]
 
 
-def test_update_subscribe_uses_reload_helper(monkeypatch):
-    calls = []
+@pytest.mark.parametrize(
+    (
+        "member",
+        "subscribe_str",
+        "expected_result",
+        "expected_update",
+    ),
+    [
+        (
+            None,
+            "discord",
+            {"success": False, "message": "找不到您的社員資料，請先透過 Email 綁定身分。"},
+            None,
+        ),
+        (
+            _valid_member(valid_date=PAST_VALID_DATE),
+            "discord",
+            {"success": False, "message": "您的社員資格已過期，無法設定訂閱。"},
+            None,
+        ),
+        (
+            _valid_member(subscribe="discord"),
+            "",
+            {"success": True, "message": "已取消所有通知訂閱。"},
+            ("alice@example.com", "subscribe", ""),
+        ),
+        (
+            _valid_member(subscribe="discord"),
+            "   ",
+            {"success": True, "message": "已取消所有通知訂閱。"},
+            ("alice@example.com", "subscribe", ""),
+        ),
+        (
+            _valid_member(),
+            ",,, line ,,",
+            {"success": False, "message": "不支援的平台: line。目前僅支援: discord"},
+            None,
+        ),
+        (
+            _valid_member(discord_acc_id=""),
+            "discord",
+            {
+                "success": False,
+                "message": "您尚未綁定 discord 帳號，請先綁定後再訂閱該平台的通知。",
+            },
+            None,
+        ),
+        (
+            _valid_member(discord_acc_id="0"),
+            "discord",
+            {
+                "success": False,
+                "message": "您尚未綁定 discord 帳號，請先綁定後再訂閱該平台的通知。",
+            },
+            None,
+        ),
+        (
+            _valid_member(discord_acc_id="discord-1"),
+            " Discord, discord ",
+            {"success": True, "message": "訂閱設定已更新！您將在以下平台收到每日課程通知：discord"},
+            ("alice@example.com", "subscribe", "discord"),
+        ),
+    ],
+)
+def test_update_subscribe_handles_edge_cases_without_real_db_or_api(
+    monkeypatch,
+    member,
+    subscribe_str,
+    expected_result,
+    expected_update,
+):
+    lookup_calls = []
+    update_calls = []
 
     def fake_lookup_with_reload(platform, account_id):
-        calls.append((platform, account_id))
-        return _valid_member(subscribe="", discord_acc_id="discord-1")
+        lookup_calls.append((platform, account_id))
+        return member
 
     def fake_update_member_field(email, field, value):
+        update_calls.append((email, field, value))
         return {"success": True, "message": "更新成功"}
 
     monkeypatch.setattr(member_store, "_lookup_member_with_reload", fake_lookup_with_reload)
     monkeypatch.setattr(member_store, "_update_member_field", fake_update_member_field)
 
-    result = member_store.update_subscribe("Discord", "discord-1", "discord")
+    result = member_store.update_subscribe("Discord", "discord-1", subscribe_str)
 
-    assert result["success"] is True
-    assert result["message"] == "訂閱設定已更新！您將在以下平台收到每日課程通知：discord"
-    assert calls == [("Discord", "discord-1")]
+    assert result == expected_result
+    assert lookup_calls == [("Discord", "discord-1")]
+    assert update_calls == ([] if expected_update is None else [expected_update])


### PR DESCRIPTION
## Summary
Add table-driven tests for member role classification, platform mapping, member validity, and subscription edge cases.

## Related Issue
Fixes #17

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration or deployment
- [x] Tests

## Changes
- Convert member domain tests to table-driven cases for validity, tier roles, platform fields, and subscription parsing.
- Add table-driven service tests for `get_member_role` covering non-member, STAFF, VIP, normal member, and expired member behavior.
- Add table-driven service tests for `update_subscribe` covering missing member, expired member, unsubscribe, malformed/unsupported platforms, unbound Discord account, and successful Discord subscription.
- Mock lookup/update helpers so tests do not read/write the real member DB or call APIs.

## Coverage
Before (`uv run pytest -q` on base branch):
- Total: 34%
- `src/ian/domain/members.py`: 91%
- `src/ian/services/member_store.py`: 37%

After (`uv run pytest -q` on this branch):
- Total: 35%
- `src/ian/domain/members.py`: 97%
- `src/ian/services/member_store.py`: 47%

## Testing
- [x] Local tests or checks pass
- [ ] Manual verification completed
- [ ] Not tested; reason:

Commands run:
- `uv run pytest tests/domain/test_members.py -q`
- `uv run pytest tests/domain/test_members.py tests/services/test_member_store_lookup_reload.py -q`
- `uv run pytest -q` (`91 passed`; coverage report displayed, total 35%)
- `make precommit`

## Impact Checklist
- [ ] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [ ] Webhook behavior checked, if affected
- [ ] Docker or compose changes checked, if affected
- [ ] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

## Notes for Reviewers
No production code changed.
