### PR TITLE
[Refactor]: split member store helpers

### DIFF
--- a/src/ian/domain/members.py
+++ b/src/ian/domain/members.py
@@ -54,3 +54,12 @@ def normalize_email(email: str) -> str:
 def parse_subscribe_platforms(subscribe_str: str) -> list[str]:
     raw_platforms = [p.strip().lower() for p in subscribe_str.split(",") if p.strip()]
     return sorted(set(raw_platforms))
+
+
+def invalid_subscribe_platforms(subscribe_str: str) -> list[str]:
+    raw_platforms = [p.strip().lower() for p in subscribe_str.split(",") if p.strip()]
+    return [p for p in raw_platforms if p not in VALID_SUBSCRIBE_PLATFORMS]
+
+
+def normalize_personal_prompt(prompt_text: str) -> str:
+    return prompt_text.strip()[:PERSONAL_PROMPT_MAX_LEN]

--- a/src/ian/services/member_api.py
+++ b/src/ian/services/member_api.py
@@ -1,0 +1,62 @@
+import requests
+
+
+class MemberApiError(Exception):
+    """Raised when the member API cannot complete a requested operation."""
+
+
+def _require_config(api_url: str, api_key: str) -> None:
+    if not api_url or not api_key:
+        raise MemberApiError("MEMBER_API_URL or MEMBER_API_KEY is not configured")
+
+
+def fetch_members(api_url: str, api_key: str) -> list[dict]:
+    """Fetch member records from the remote member API."""
+    _require_config(api_url, api_key)
+
+    resp = requests.get(
+        api_url,
+        params={"api_key": api_key},
+        timeout=30,
+        allow_redirects=True,
+    )
+    resp.raise_for_status()
+    payload = resp.json()
+
+    if payload.get("status") != "success":
+        message = payload.get("message") or payload.get("status") or "unknown error"
+        raise MemberApiError(str(message))
+
+    data = payload.get("data", [])
+    if not data:
+        raise MemberApiError("empty data")
+
+    return data
+
+
+def update_member_fields(
+    api_url: str,
+    api_key: str,
+    email: str,
+    fields: dict[str, str],
+) -> None:
+    """Update one member record in the remote member API."""
+    _require_config(api_url, api_key)
+
+    payload = {
+        "api_key": api_key,
+        "email": email,
+        **fields,
+    }
+    resp = requests.post(
+        api_url,
+        json=payload,
+        timeout=30,
+        allow_redirects=True,
+    )
+    resp.raise_for_status()
+    result = resp.json()
+
+    if result.get("status") != "success":
+        message = result.get("message") or result.get("status") or "未知錯誤"
+        raise MemberApiError(str(message))

--- a/src/ian/services/member_cache.py
+++ b/src/ian/services/member_cache.py
@@ -1,0 +1,68 @@
+import json
+import threading
+from pathlib import Path
+
+from ian.domain.members import PLATFORM_FIELD_MAP, normalize_email
+
+
+class MemberCache:
+    """Local JSON-backed member cache with synchronized in-memory access."""
+
+    def __init__(self, path: Path, members: list[dict] | None = None):
+        self.path = path
+        self._members = members or []
+        self._lock = threading.Lock()
+
+    def load(self) -> list[dict] | None:
+        if not self.path.exists():
+            return None
+
+        members = json.loads(self.path.read_text(encoding="utf-8"))
+        self.replace_all(members)
+        return members
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(
+            json.dumps(self.all(), ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    def replace_all(self, members: list[dict]) -> None:
+        with self._lock:
+            self._members = members
+
+    def all(self) -> list[dict]:
+        with self._lock:
+            return list(self._members)
+
+    def find_by_platform(self, platform: str, account_id: str) -> dict | None:
+        field = PLATFORM_FIELD_MAP.get(platform)
+        if not field or not account_id:
+            return None
+
+        normalized_account_id = account_id.strip()
+        with self._lock:
+            for member in self._members:
+                stored_id = str(member.get(field, "")).strip()
+                if stored_id and stored_id == normalized_account_id:
+                    return member
+        return None
+
+    def find_by_email(self, email: str) -> dict | None:
+        normalized = normalize_email(email)
+        with self._lock:
+            for member in self._members:
+                stored_email = normalize_email(member.get("email", ""))
+                if stored_email and stored_email == normalized:
+                    return member
+        return None
+
+    def update_field(self, email: str, field: str, value: str) -> bool:
+        normalized = normalize_email(email)
+        with self._lock:
+            for member in self._members:
+                if normalize_email(member.get("email", "")) == normalized:
+                    member[field] = value
+                    return True
+        return False

--- a/src/ian/services/member_store.py
+++ b/src/ian/services/member_store.py
@@ -1,30 +1,28 @@
-import json
 import threading
 import time
 from datetime import datetime, timedelta
 from typing import Optional
 
-import requests
-
 from ian.config import MEMBER_API_KEY, MEMBER_API_URL, MEMBER_DB_FILE, TZ_TPE
 from ian.domain.members import (
-    PERSONAL_PROMPT_MAX_LEN,
     PLATFORM_FIELD_MAP,
     SUBSCRIBE_PLATFORM_FIELD as _SUBSCRIBE_PLATFORM_FIELD,
     VALID_SUBSCRIBE_PLATFORMS,
     get_role_from_tier,
+    invalid_subscribe_platforms,
     is_valid_member,
-    normalize_email,
+    normalize_personal_prompt,
+    parse_subscribe_platforms,
 )
+from ian.services.member_api import MemberApiError, fetch_members, update_member_fields
+from ian.services.member_cache import MemberCache
 from ian.utils.console import eprint
 
 
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-# In-memory member data (list of dicts)
-_member_data: list[dict] = []
-_member_lock = threading.Lock()
+_cache = MemberCache(MEMBER_DB_FILE)
 
 # ---------------------------------------------------------------------------
 # Sync from API
@@ -32,42 +30,16 @@ _member_lock = threading.Lock()
 def sync_member_data() -> bool:
     """Fetch latest member data from API and save to local file."""
     try:
-        if not MEMBER_API_URL or not MEMBER_API_KEY:
-            eprint("[MemberDB] MEMBER_API_URL or MEMBER_API_KEY is not configured")
-            return False
-
         eprint("[MemberDB] Syncing member data from API...")
-        resp = requests.get(
-            MEMBER_API_URL,
-            params={"api_key": MEMBER_API_KEY},
-            timeout=30,
-            allow_redirects=True,
-        )
-        resp.raise_for_status()
-        payload = resp.json()
-
-        if payload.get("status") != "success":
-            eprint(f"[MemberDB] API returned non-success: {payload.get('status')}")
-            return False
-
-        data = payload.get("data", [])
-        if not data:
-            eprint("[MemberDB] API returned empty data")
-            return False
-
-        # Save to local file
-        MEMBER_DB_FILE.parent.mkdir(parents=True, exist_ok=True)
-        MEMBER_DB_FILE.write_text(
-            json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
-        )
-
-        # Update in-memory cache
-        with _member_lock:
-            global _member_data
-            _member_data = data
+        data = fetch_members(MEMBER_API_URL, MEMBER_API_KEY)
+        _cache.replace_all(data)
+        _cache.save()
 
         eprint(f"[MemberDB] Synced {len(data)} members successfully")
         return True
+    except MemberApiError as e:
+        eprint(f"[MemberDB] Sync failed: {e}")
+        return False
     except Exception as e:
         eprint(f"[MemberDB] Sync failed: {e}")
         return False
@@ -75,15 +47,11 @@ def sync_member_data() -> bool:
 
 def load_member_db() -> bool:
     """Load member data from local file into memory."""
-    global _member_data
     try:
-        if not MEMBER_DB_FILE.exists():
+        data = _cache.load()
+        if data is None:
             eprint("[MemberDB] Local DB file not found, attempting sync...")
             return sync_member_data()
-
-        data = json.loads(MEMBER_DB_FILE.read_text(encoding="utf-8"))
-        with _member_lock:
-            _member_data = data
         eprint(f"[MemberDB] Loaded {len(data)} members from local file")
         return True
     except Exception as e:
@@ -99,16 +67,7 @@ def lookup_member_by_platform(platform: str, account_id: str) -> Optional[dict]:
 
     Returns the member dict if found, None otherwise.
     """
-    field = PLATFORM_FIELD_MAP.get(platform)
-    if not field or not account_id:
-        return None
-
-    with _member_lock:
-        for member in _member_data:
-            stored_id = str(member.get(field, "")).strip()
-            if stored_id and stored_id == account_id.strip():
-                return member
-    return None
+    return _cache.find_by_platform(platform, account_id)
 
 
 def _lookup_member_with_reload(platform: str, account_id: str) -> Optional[dict]:
@@ -151,13 +110,7 @@ def get_member_role(platform: str, account_id: str) -> str:
 # ---------------------------------------------------------------------------
 def find_member_by_email(email: str) -> Optional[dict]:
     """Find a member by email (case-insensitive on local part)."""
-    normalized = normalize_email(email)
-    with _member_lock:
-        for member in _member_data:
-            stored_email = normalize_email(member.get("email", ""))
-            if stored_email and stored_email == normalized:
-                return member
-    return None
+    return _cache.find_by_email(email)
 
 
 def bind_email(email: str, platform: str, account_id: str) -> dict:
@@ -210,17 +163,16 @@ def bind_email(email: str, platform: str, account_id: str) -> dict:
         }
 
     # Prevent re-binding: this account is already bound to a different email
-    with _member_lock:
-        for m in _member_data:
-            stored_id = str(m.get(field, "")).strip()
-            if stored_id and stored_id == account_id.strip():
-                return {
-                    "success": False,
-                    "message": (
-                        f"此 {platform} 帳號已綁定身分，無法一個帳號綁定多個身分。"
-                        "如需變更，請聯繫幹部協助處理。"
-                    ),
-                }
+    for m in _cache.all():
+        stored_id = str(m.get(field, "")).strip()
+        if stored_id and stored_id == account_id.strip():
+            return {
+                "success": False,
+                "message": (
+                    f"此 {platform} 帳號已綁定身分，無法一個帳號綁定多個身分。"
+                    "如需變更，請聯繫幹部協助處理。"
+                ),
+            }
 
     # Check if valid
     if not is_valid_member(member):
@@ -231,41 +183,23 @@ def bind_email(email: str, platform: str, account_id: str) -> dict:
 
     # 2. POST to API
     try:
-        payload = {
-            "api_key": MEMBER_API_KEY,
-            "email": member.get("email", ""),  # Use original email from DB
-            field: account_id,
-        }
-        resp = requests.post(
+        update_member_fields(
             MEMBER_API_URL,
-            json=payload,
-            timeout=30,
-            allow_redirects=True,
+            MEMBER_API_KEY,
+            member.get("email", ""),
+            {field: account_id},
         )
-        resp.raise_for_status()
-        result = resp.json()
-
-        if result.get("status") != "success":
-            return {
-                "success": False,
-                "message": f"API 更新失敗: {result.get('message', '未知錯誤')}",
-            }
+    except MemberApiError as e:
+        return {"success": False, "message": f"API 更新失敗: {e}"}
     except Exception as e:
         return {"success": False, "message": f"綁定時發生錯誤: {e}"}
 
     # 3. Update local cache
-    with _member_lock:
-        for m in _member_data:
-            if normalize_email(m.get("email", "")) == normalize_email(email):
-                m[field] = account_id
-                break
+    _cache.update_field(email, field, account_id)
 
     # Save updated data to local file
     try:
-        MEMBER_DB_FILE.write_text(
-            json.dumps(_member_data, ensure_ascii=False, indent=2),
-            encoding="utf-8",
-        )
+        _cache.save()
     except Exception as e:
         eprint(f"[MemberDB] Failed to save local DB after binding: {e}")
 
@@ -273,12 +207,10 @@ def bind_email(email: str, platform: str, account_id: str) -> dict:
     role = get_role_from_tier(member.get("Tier", ""))
 
     # Build bound platforms summary (use updated member dict)
-    with _member_lock:
-        updated = next(
-            (m for m in _member_data if normalize_email(m.get("email", "")) == normalize_email(email)),
-            member,
-        )
-    bound_platforms = [p for p, f in PLATFORM_FIELD_MAP.items() if str(updated.get(f, "")).strip()]
+    updated = _cache.find_by_email(email) or member
+    bound_platforms = [
+        p for p, f in PLATFORM_FIELD_MAP.items() if str(updated.get(f, "")).strip()
+    ]
     bound_str = "、".join(bound_platforms) if bound_platforms else "無"
 
     return {
@@ -293,40 +225,22 @@ def bind_email(email: str, platform: str, account_id: str) -> dict:
 def _update_member_field(email: str, field: str, value: str) -> dict:
     """POST a single field update to the API and update local cache."""
     try:
-        payload = {
-            "api_key": MEMBER_API_KEY,
-            "email": email,
-            field: value,
-        }
-        resp = requests.post(
+        update_member_fields(
             MEMBER_API_URL,
-            json=payload,
-            timeout=30,
-            allow_redirects=True,
+            MEMBER_API_KEY,
+            email,
+            {field: value},
         )
-        resp.raise_for_status()
-        result = resp.json()
-
-        if result.get("status") != "success":
-            return {
-                "success": False,
-                "message": f"API 更新失敗: {result.get('message', '未知錯誤')}",
-            }
+    except MemberApiError as e:
+        return {"success": False, "message": f"API 更新失敗: {e}"}
     except Exception as e:
         return {"success": False, "message": f"更新時發生錯誤: {e}"}
 
     # Update local cache
-    with _member_lock:
-        for m in _member_data:
-            if normalize_email(m.get("email", "")) == normalize_email(email):
-                m[field] = value
-                break
+    _cache.update_field(email, field, value)
 
     try:
-        MEMBER_DB_FILE.write_text(
-            json.dumps(_member_data, ensure_ascii=False, indent=2),
-            encoding="utf-8",
-        )
+        _cache.save()
     except Exception as e:
         eprint(f"[MemberDB] Failed to save local DB after update: {e}")
 
@@ -362,16 +276,14 @@ def update_subscribe(platform: str, account_id: str, subscribe_str: str) -> dict
             result["message"] = "已取消所有通知訂閱。"
         return result
 
-    raw_platforms = [p.strip().lower() for p in subscribe_str.split(",") if p.strip()]
-    invalid = [p for p in raw_platforms if p not in VALID_SUBSCRIBE_PLATFORMS]
+    invalid = invalid_subscribe_platforms(subscribe_str)
     if invalid:
         return {
             "success": False,
             "message": f"不支援的平台: {', '.join(invalid)}。目前僅支援: {', '.join(sorted(VALID_SUBSCRIBE_PLATFORMS))}",
         }
 
-    # Deduplicate
-    platforms = sorted(set(raw_platforms))
+    platforms = parse_subscribe_platforms(subscribe_str)
 
     # Check that the member has bound the requested platforms
     unbound = []
@@ -411,10 +323,7 @@ def update_personal_prompt(platform: str, account_id: str, prompt_text: str) -> 
     if not member:
         return {"success": False, "message": "找不到您的社員資料，無法更新個人備註。"}
 
-    text = prompt_text.strip()
-    if len(text) > PERSONAL_PROMPT_MAX_LEN:
-        text = text[:PERSONAL_PROMPT_MAX_LEN]
-
+    text = normalize_personal_prompt(prompt_text)
     result = _update_member_field(member.get("email", ""), "personal_prompt", text)
     if result["success"]:
         result["message"] = "已更新使用者個性備註。"

--- a/tests/domain/test_members.py
+++ b/tests/domain/test_members.py
@@ -4,8 +4,10 @@ import pytest
 
 from ian.domain.members import (
     get_role_from_tier,
+    invalid_subscribe_platforms,
     is_valid_member,
     normalize_email,
+    normalize_personal_prompt,
     parse_subscribe_platforms,
     platform_field,
 )
@@ -81,3 +83,15 @@ def test_parse_subscribe_platforms_trims_lowercases_deduplicates_and_sorts(
     subscribe_str, expected
 ):
     assert parse_subscribe_platforms(subscribe_str) == expected
+
+
+def test_invalid_subscribe_platforms_preserves_invalid_entries_for_messages():
+    assert invalid_subscribe_platforms(" Discord, line, fb, LINE ") == [
+        "line",
+        "fb",
+        "line",
+    ]
+
+
+def test_normalize_personal_prompt_strips_and_truncates_to_limit():
+    assert normalize_personal_prompt(f"  {'a' * 101}  ") == "a" * 100

--- a/tests/services/test_member_api.py
+++ b/tests/services/test_member_api.py
@@ -1,0 +1,106 @@
+import pytest
+import requests
+
+from ian.services.member_api import MemberApiError, fetch_members, update_member_fields
+
+
+class FakeResponse:
+    def __init__(self, payload, *, raises=None):
+        self._payload = payload
+        self._raises = raises
+
+    def raise_for_status(self):
+        if self._raises:
+            raise self._raises
+
+    def json(self):
+        return self._payload
+
+
+def test_fetch_members_returns_api_data(monkeypatch):
+    calls = []
+
+    def fake_get(url, *, params, timeout, allow_redirects):
+        calls.append((url, params, timeout, allow_redirects))
+        return FakeResponse({"status": "success", "data": [{"id": "Alice"}]})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert fetch_members("https://api.example.test/members", "secret") == [{"id": "Alice"}]
+    assert calls == [
+        (
+            "https://api.example.test/members",
+            {"api_key": "secret"},
+            30,
+            True,
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"status": "error", "message": "bad key"}, "bad key"),
+        ({"status": "failed"}, "failed"),
+        ({"status": "success", "data": []}, "empty data"),
+    ],
+)
+def test_fetch_members_raises_clear_error_for_failed_payloads(
+    monkeypatch, payload, message
+):
+    monkeypatch.setattr(
+        requests,
+        "get",
+        lambda *args, **kwargs: FakeResponse(payload),
+    )
+
+    with pytest.raises(MemberApiError, match=message):
+        fetch_members("https://api.example.test/members", "secret")
+
+
+def test_update_member_fields_posts_api_key_email_and_fields(monkeypatch):
+    calls = []
+
+    def fake_post(url, *, json, timeout, allow_redirects):
+        calls.append((url, json, timeout, allow_redirects))
+        return FakeResponse({"status": "success"})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    update_member_fields(
+        "https://api.example.test/members",
+        "secret",
+        "alice@example.com",
+        {"discord_acc_id": "discord-1"},
+    )
+
+    assert calls == [
+        (
+            "https://api.example.test/members",
+            {
+                "api_key": "secret",
+                "email": "alice@example.com",
+                "discord_acc_id": "discord-1",
+            },
+            30,
+            True,
+        )
+    ]
+
+
+def test_update_member_fields_raises_api_message_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: FakeResponse(
+            {"status": "error", "message": "locked"}
+        ),
+    )
+
+    with pytest.raises(MemberApiError, match="locked"):
+        update_member_fields(
+            "https://api.example.test/members",
+            "secret",
+            "alice@example.com",
+            {"discord_acc_id": "discord-1"},
+        )

--- a/tests/services/test_member_cache.py
+++ b/tests/services/test_member_cache.py
@@ -1,0 +1,65 @@
+from ian.services.member_cache import MemberCache
+
+
+def test_member_cache_loads_and_saves_json_file(tmp_path):
+    cache_file = tmp_path / "member_db.json"
+    cache_file.write_text('[{"id": "Alice", "email": "alice@example.com"}]', encoding="utf-8")
+    cache = MemberCache(cache_file)
+
+    assert cache.load() == [{"id": "Alice", "email": "alice@example.com"}]
+
+    cache.replace_all([{"id": "Bob", "email": "bob@example.com"}])
+    cache.save()
+
+    assert cache_file.read_text(encoding="utf-8") == (
+        '[\n'
+        '  {\n'
+        '    "id": "Bob",\n'
+        '    "email": "bob@example.com"\n'
+        '  }\n'
+        ']'
+    )
+
+
+def test_member_cache_load_returns_none_when_file_is_missing(tmp_path):
+    cache = MemberCache(tmp_path / "missing.json")
+
+    assert cache.load() is None
+    assert cache.all() == []
+
+
+def test_member_cache_finds_members_by_platform_and_email(tmp_path):
+    cache = MemberCache(
+        tmp_path / "member_db.json",
+        [
+            {
+                "id": "Alice",
+                "email": "Alice@Example.COM",
+                "discord_acc_id": " discord-1 ",
+            },
+            {"id": "Bob", "email": "bob@example.com", "discord_acc_id": ""},
+        ],
+    )
+
+    assert cache.find_by_platform("Discord", "discord-1")["id"] == "Alice"
+    assert cache.find_by_platform("Discord", "missing") is None
+    assert cache.find_by_platform("Slack", "discord-1") is None
+    assert cache.find_by_email("alice@Example.COM")["id"] == "Alice"
+    assert cache.find_by_email("ALICE@example.com") is None
+
+
+def test_member_cache_update_field_mutates_matching_email_only(tmp_path):
+    cache = MemberCache(
+        tmp_path / "member_db.json",
+        [
+            {"email": "alice@example.com", "subscribe": ""},
+            {"email": "bob@example.com", "subscribe": ""},
+        ],
+    )
+
+    assert cache.update_field("ALICE@example.com", "subscribe", "discord")
+    assert cache.all() == [
+        {"email": "alice@example.com", "subscribe": "discord"},
+        {"email": "bob@example.com", "subscribe": ""},
+    ]
+    assert not cache.update_field("missing@example.com", "subscribe", "discord")


### PR DESCRIPTION
## Summary

Split `member_store` responsibilities into focused API and cache helpers while keeping `ian.services.member_store` as the public facade for existing gateways, MCP tools, reminders, and agent runtime.

## Related Issue

Fixes #77

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Configuration or deployment
- [x] Tests

## Changes

- Added `ian.services.member_api` for remote member API fetch/update calls and mocked success/failure-path tests.
- Added `ian.services.member_cache` for JSON-backed local cache load/save, lookup, and mutation with temp-file tests.
- Simplified `member_store.py` into orchestration/facade logic and moved small subscription/prompt normalization rules into `ian.domain.members`.

## Testing

- [x] Local tests or checks pass
- [x] Manual verification completed
- [ ] Not tested; reason:

Commands run:

- `uv run pytest tests/services/test_member_api.py tests/services/test_member_cache.py tests/services/test_member_store_lookup_reload.py tests/domain/test_members.py`
- `uv run ruff check src/ian/services/member_api.py src/ian/services/member_cache.py src/ian/services/member_store.py src/ian/domain/members.py tests/services/test_member_api.py tests/services/test_member_cache.py tests/domain/test_members.py`
- `make test`
- `make precommit`

## Impact Checklist

- [ ] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [ ] Webhook behavior checked, if affected
- [ ] Docker or compose changes checked, if affected
- [ ] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

## Notes for Reviewers

This is intended as the first scoped pass for #77: API and local cache responsibilities are isolated, while existing `member_store` public function names and call sites are preserved for follow-up migration.