### PR TITLE
[Test]: cover course parsing and permission filtering

### DIFF
--- a/src/ian/domain/courses.py
+++ b/src/ian/domain/courses.py
@@ -110,9 +110,9 @@ def format_course_data(df: pd.DataFrame, has_permission: bool) -> str:
     for index, row in df.iterrows():
         course_info = []
         for col in df.columns:
-            value = row[col]
+            value = clean_value(row[col])
             friendly_col_name = column_mapping.get(col, str(col))
-            has_value = pd.notna(value) and str(value).strip()
+            has_value = bool(value)
 
             if has_value:
                 if not has_permission and friendly_col_name in MEMBER_ONLY_FIELDS:

--- a/tests/domain/test_courses.py
+++ b/tests/domain/test_courses.py
@@ -22,6 +22,7 @@ import pandas as pd
 
 from ian.domain.courses import (
     MEMBER_ONLY_FIELDS,
+    clean_value,
     format_course_data,
     get_column_mapping,
     normalize_date,
@@ -32,6 +33,18 @@ from ian.domain.courses import (
 def test_parse_dates_from_query_normalizes_full_dates():
     assert parse_dates_from_query("請查 2026-3-7 的社課") == ["2026/03/07"]
     assert normalize_date(2026, 3, 7) == "2026/03/07"
+
+
+def test_parse_dates_from_query_uses_current_year_for_short_dates():
+    assert parse_dates_from_query("3/7", current_year=2026) == ["2026/03/07"]
+    assert parse_dates_from_query("03-07", current_year=2026) == ["2026/03/07"]
+
+
+def test_clean_value_removes_empty_and_placeholder_values():
+    assert clean_value(float("nan")) == ""
+    assert clean_value(" - ") == ""
+    assert clean_value("無") == ""
+    assert clean_value(" 生成式 AI ") == "生成式 AI"
 
 
 def test_get_column_mapping_repairs_encoded_column_by_position():
@@ -60,3 +73,24 @@ def test_format_course_data_hides_member_only_fields_for_non_members():
     assert all(field not in public_text for field in MEMBER_ONLY_FIELDS)
     assert "線上連結: https://meet.example" in member_text
     assert "課程講義: (尚未上傳)" in member_text
+
+
+def test_format_course_data_cleans_empty_and_placeholder_values():
+    df = pd.DataFrame(
+        [
+            {
+                "時間": "2026/03/07",
+                "社課主題/活動名稱": "生成式 AI",
+                "場地": "-",
+                "講者": "無",
+                "課程講義": "-",
+            }
+        ]
+    )
+
+    text = format_course_data(df, has_permission=True)
+
+    assert "社課主題/活動名稱: 生成式 AI" in text
+    assert "場地:" not in text
+    assert "講者:" not in text
+    assert "課程講義: (尚未上傳)" in text

--- a/tests/services/test_course_catalog.py
+++ b/tests/services/test_course_catalog.py
@@ -19,15 +19,48 @@
 #
 
 import time
+from datetime import datetime
 
 import pandas as pd
 
+from ian.config import TZ_TPE
 from ian.services import course_catalog
 
 
 def setup_function():
     course_catalog.course_data = None
     course_catalog.last_course_update = None
+
+
+def _course_fixture():
+    return pd.DataFrame(
+        [
+            {
+                "時間": "2026/03/07",
+                "社課主題/活動名稱": "生成式 AI",
+                "線上連結": "https://meet.example/genai",
+                "課程講義": "https://slides.example/genai",
+            },
+            {
+                "時間": "2026/03/14",
+                "社課主題/活動名稱": "資料科學",
+                "線上連結": "https://meet.example/data",
+                "課程講義": "",
+            },
+            {
+                "時間": "2026/04/04",
+                "社課主題/活動名稱": "遠期活動",
+                "線上連結": "https://meet.example/future",
+                "課程講義": "",
+            },
+        ]
+    )
+
+
+class FixedDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return datetime(2026, 3, 1, 12, 0, tzinfo=TZ_TPE)
 
 
 def test_search_course_data_by_query_matches_normalized_date():
@@ -44,6 +77,52 @@ def test_search_course_data_by_query_matches_normalized_date():
     assert "找到 1 筆課程資料" in result
     assert "生成式 AI" in result
     assert "資料科學" not in result
+
+
+def test_search_course_data_by_query_matches_date_range_from_in_memory_fixture():
+    course_catalog.course_data = _course_fixture()
+
+    found, result = course_catalog.search_course_data_by_query(
+        "2026/03/01 到 2026/03/31", has_permission=True
+    )
+
+    assert found
+    assert "找到 2 筆課程資料" in result
+    assert "生成式 AI" in result
+    assert "資料科學" in result
+    assert "遠期活動" not in result
+
+
+def test_search_course_data_by_query_filters_member_only_fields_by_permission():
+    course_catalog.course_data = _course_fixture()
+
+    public_found, public_result = course_catalog.search_course_data_by_query(
+        "生成式 AI", has_permission=False
+    )
+    member_found, member_result = course_catalog.search_course_data_by_query(
+        "生成式 AI", has_permission=True
+    )
+
+    assert public_found
+    assert member_found
+    assert "社課主題/活動名稱: 生成式 AI" in public_result
+    assert "線上連結:" not in public_result
+    assert "課程講義:" not in public_result
+    assert "線上連結: https://meet.example/genai" in member_result
+    assert "課程講義: https://slides.example/genai" in member_result
+
+
+def test_get_upcoming_courses_uses_in_memory_fixture_and_current_date(monkeypatch):
+    course_catalog.course_data = _course_fixture()
+    monkeypatch.setattr(course_catalog, "datetime", FixedDateTime)
+
+    result = course_catalog.get_upcoming_courses(has_permission=False, weeks=2)
+
+    assert "近期課程（未來 2 週），共 2 筆" in result
+    assert "生成式 AI" in result
+    assert "資料科學" in result
+    assert "遠期活動" not in result
+    assert "線上連結:" not in result
 
 
 def test_load_course_data_uses_valid_cache(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Add focused course catalog tests for date parsing, placeholder cleanup, permission filtering, and upcoming-course selection. Also route formatted course values through the existing cleanup helper so placeholder values do not leak into user-facing course output.

## Related Issue

Fixes #18

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration or deployment
- [x] Tests

## Changes

- Added domain tests for short-date parsing, placeholder normalization, and course formatting cleanup.
- Added service tests using in-memory course fixtures for date range search, member-only field filtering, and upcoming-course selection.
- Updated `format_course_data()` to use `clean_value()` before deciding whether to show a field.

## Testing

- [x] Local tests or checks pass
- [ ] Manual verification completed
- [ ] Not tested; reason:

Commands run:

```bash
uv run pytest tests/domain/test_courses.py tests/services/test_course_catalog.py
make test
make precommit
```

## Impact Checklist

- [ ] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [ ] Webhook behavior checked, if affected
- [ ] Docker or compose changes checked, if affected
- [ ] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

## Notes for Reviewers

Course catalog tests use local in-memory pandas fixtures only and do not call Google Sheets or external services.
