### PR TITLE
[Test]: cover webhook adapter routing

### DIFF
--- a/src/ian/gateways/webhook_server.py
+++ b/src/ian/gateways/webhook_server.py
@@ -47,12 +47,13 @@ def configure_platforms(platform: str = "all") -> set[str]:
     ENABLED_WEBHOOK_PLATFORMS = selected.copy()
     return ENABLED_WEBHOOK_PLATFORMS
 
-# Initialize member database
-try:
-    init_member_db()
-    eprint("社員資料庫已初始化 (webhook_server)")
-except Exception as e:
-    eprint(f"社員資料庫初始化失敗: {e}")
+def initialize_dependencies() -> None:
+    """Initialize external member data when the webhook server starts."""
+    try:
+        init_member_db()
+        eprint("社員資料庫已初始化 (webhook_server)")
+    except Exception as e:
+        eprint(f"社員資料庫初始化失敗: {e}")
 
 
 @app.route('/', methods=['GET'])
@@ -107,6 +108,7 @@ def status():
     }, 200
 
 def entrypoint(platform: str = "all"):
+    initialize_dependencies()
     enabled = configure_platforms(platform)
     print(f"啟動 Flask 伺服器... platforms={', '.join(sorted(enabled))}")
     app.run(host='0.0.0.0', port=5190, debug=False)

--- a/tests/gateways/test_facebook_webhook.py
+++ b/tests/gateways/test_facebook_webhook.py
@@ -1,0 +1,215 @@
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (c) 2026 NTU AI Club
+#
+# This file is part of Ian, an open-source AI agent framework developed
+# and maintained by NTU AI Club.
+#
+# Ian is licensed under the GNU General Public License, either version 3
+# of the License, or (at your option) any later version.
+#
+# Ian is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ian. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import asyncio
+
+import pytest
+
+from ian.gateways import facebook_webhook
+from ian.gateways.agent_bridge import AgentMessageResult
+
+
+def test_cleanup_processed_messages_removes_only_expired_entries(monkeypatch):
+    monkeypatch.setattr(
+        facebook_webhook,
+        "PROCESSED_MESSAGES",
+        {"expired": 399.0, "boundary": 400.0, "recent": 999.0},
+    )
+    monkeypatch.setattr(facebook_webhook.time, "time", lambda: 1000.0)
+
+    facebook_webhook.cleanup_processed_messages()
+
+    assert facebook_webhook.PROCESSED_MESSAGES == {
+        "boundary": 400.0,
+        "recent": 999.0,
+    }
+
+
+@pytest.mark.parametrize(
+    ("message", "processed_messages"),
+    [
+        pytest.param(
+            {"mid": "duplicate", "text": "hello"},
+            {"duplicate": 1.0},
+            id="duplicate-mid",
+        ),
+        pytest.param(
+            {"mid": "echo", "text": "hello", "is_echo": True},
+            {},
+            id="echo",
+        ),
+        pytest.param({"text": "hello"}, {}, id="missing-mid"),
+    ],
+)
+def test_handle_facebook_messages_skips_nonprocessable_messages(
+    monkeypatch, message, processed_messages
+):
+    expected_processed_messages = processed_messages.copy()
+    monkeypatch.setattr(facebook_webhook, "PROCESSED_MESSAGES", processed_messages)
+    monkeypatch.setattr(facebook_webhook, "cleanup_processed_messages", lambda: None)
+    monkeypatch.setattr(
+        facebook_webhook,
+        "process_message_task",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("message should not be processed")
+        ),
+    )
+
+    facebook_webhook.handle_facebook_messages(
+        {
+            "entry": [
+                {
+                    "messaging": [
+                        {"sender": {"id": "sender-1"}, "message": message}
+                    ]
+                }
+            ]
+        }
+    )
+
+    assert facebook_webhook.PROCESSED_MESSAGES == expected_processed_messages
+
+
+def test_handle_facebook_messages_routes_new_message_to_background_task(monkeypatch):
+    processed = []
+
+    async def fake_process(sender_id, text, mid):
+        processed.append((sender_id, text, mid))
+
+    class ImmediateThread:
+        def __init__(self, target, args):
+            self.target = target
+            self.args = args
+
+        def start(self):
+            self.target(*self.args)
+
+    monkeypatch.setattr(facebook_webhook, "PROCESSED_MESSAGES", {})
+    monkeypatch.setattr(facebook_webhook, "cleanup_processed_messages", lambda: None)
+    monkeypatch.setattr(facebook_webhook.time, "time", lambda: 123.0)
+    monkeypatch.setattr(facebook_webhook, "process_message_task", fake_process)
+    monkeypatch.setattr(facebook_webhook.threading, "Thread", ImmediateThread)
+
+    facebook_webhook.handle_facebook_messages(
+        {
+            "entry": [
+                {
+                    "messaging": [
+                        {
+                            "sender": {"id": "sender-1"},
+                            "message": {"mid": "mid-1", "text": "hello"},
+                        }
+                    ]
+                }
+            ]
+        }
+    )
+
+    assert facebook_webhook.PROCESSED_MESSAGES == {"mid-1": 123.0}
+    assert processed == [("sender-1", "hello", "mid-1")]
+
+
+@pytest.mark.parametrize(
+    ("csv_content", "username", "expected"),
+    [
+        pytest.param(
+            "FB帳號,角色\nAlice,幹部\nBob,社員\n",
+            " Alice ",
+            "幹部",
+            id="matching-member",
+        ),
+        pytest.param(
+            "FB帳號,姓名\nAlice,Alice Chen\n",
+            "Alice",
+            "非社員",
+            id="missing-role-column",
+        ),
+        pytest.param(None, "Alice", "非社員", id="missing-file"),
+    ],
+)
+def test_get_member_mapping_handles_csv_sources(
+    tmp_path, csv_content, username, expected
+):
+    source = tmp_path / "member-mapping.csv"
+    if csv_content is not None:
+        source.write_text(csv_content, encoding="utf-8")
+
+    assert facebook_webhook.get_member_mapping(username, str(source)) == expected
+
+
+@pytest.mark.parametrize(
+    ("mid", "reaction_emoji", "expected_reactions"),
+    [
+        pytest.param("mid-1", "🙏", [("sender-1", "mid-1", "🙏")], id="reaction"),
+        pytest.param("mid-1", None, [], id="no-reaction"),
+        pytest.param(None, "🙏", [], id="missing-mid"),
+    ],
+)
+def test_process_message_task_handles_no_response_reactions(
+    monkeypatch, mid, reaction_emoji, expected_reactions
+):
+    typing_calls = []
+    reactions = []
+
+    async def fake_typing(recipient_id, action):
+        typing_calls.append((recipient_id, action))
+
+    async def fake_agent(**_kwargs):
+        return AgentMessageResult(
+            text="[NO_RESPONSE]",
+            should_reply=False,
+            reaction_emoji=reaction_emoji,
+        )
+
+    monkeypatch.setattr(facebook_webhook, "send_typing_indicator", fake_typing)
+    monkeypatch.setattr(facebook_webhook, "get_fb_user_profile", lambda _id: "Alice")
+    monkeypatch.setattr(
+        facebook_webhook, "get_member_role_from_db", lambda *_args: "社員"
+    )
+    monkeypatch.setattr(facebook_webhook, "run_agent_message_flow", fake_agent)
+    monkeypatch.setattr(
+        facebook_webhook,
+        "send_reaction",
+        lambda sender_id, message_id, emoji: reactions.append(
+            (sender_id, message_id, emoji)
+        ),
+    )
+    monkeypatch.setattr(
+        facebook_webhook,
+        "send_message",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("Facebook message should not be sent")
+        ),
+    )
+    monkeypatch.setattr(
+        facebook_webhook,
+        "save_chat_history",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("no-response should not be persisted")
+        ),
+    )
+
+    asyncio.run(facebook_webhook.process_message_task("sender-1", "hello", mid=mid))
+
+    assert typing_calls == [
+        ("sender-1", "typing_on"),
+        ("sender-1", "typing_off"),
+    ]
+    assert reactions == expected_reactions

--- a/tests/gateways/test_line_webhook.py
+++ b/tests/gateways/test_line_webhook.py
@@ -1,0 +1,157 @@
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (c) 2026 NTU AI Club
+#
+# This file is part of Ian, an open-source AI agent framework developed
+# and maintained by NTU AI Club.
+#
+# Ian is licensed under the GNU General Public License, either version 3
+# of the License, or (at your option) any later version.
+#
+# Ian is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ian. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from ian.gateways import line_webhook
+from ian.gateways.agent_bridge import AgentMessageResult
+
+
+def _event(text, *, group_id=None):
+    source = SimpleNamespace(user_id="user-1")
+    if group_id is not None:
+        source.group_id = group_id
+    return SimpleNamespace(
+        message=SimpleNamespace(text=text),
+        source=source,
+        reply_token="reply-token",
+    )
+
+
+def test_handle_line_message_skips_non_whitelisted_group(monkeypatch):
+    monkeypatch.setattr(line_webhook, "LINE_ALLOWED_GROUPS", ["allowed-group"])
+    monkeypatch.setattr(
+        line_webhook.line_bot_api,
+        "reply_message",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("LINE API should not be called")
+        ),
+    )
+    monkeypatch.setattr(
+        line_webhook.requests,
+        "post",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("loading API should not be called")
+        ),
+    )
+    monkeypatch.setattr(
+        line_webhook.threading,
+        "Thread",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("background task should not start")
+        ),
+    )
+
+    assert line_webhook.handle_line_message(_event("hello", group_id="blocked")) is None
+
+
+@pytest.mark.parametrize("text", ["", "   "])
+def test_handle_line_message_replies_to_empty_message(monkeypatch, text):
+    replies = []
+    monkeypatch.setattr(
+        line_webhook.line_bot_api,
+        "reply_message",
+        lambda token, message: replies.append((token, message.text)),
+    )
+    monkeypatch.setattr(
+        line_webhook.requests,
+        "post",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("loading API should not be called")
+        ),
+    )
+
+    line_webhook.handle_line_message(_event(text))
+
+    assert replies == [("reply-token", "請輸入您的問題！")]
+
+
+def _stub_line_task(monkeypatch, agent_result):
+    replies = []
+    history = []
+
+    async def fake_agent(**_kwargs):
+        return agent_result
+
+    monkeypatch.setattr(line_webhook, "get_line_user_profile", lambda _id: "Alice")
+    monkeypatch.setattr(
+        line_webhook, "get_member_role_from_db", lambda *_args: "社員"
+    )
+    monkeypatch.setattr(line_webhook, "run_agent_message_flow", fake_agent)
+    monkeypatch.setattr(
+        line_webhook.line_bot_api,
+        "reply_message",
+        lambda token, messages: replies.append((token, messages)),
+    )
+    monkeypatch.setattr(
+        line_webhook,
+        "save_chat_history",
+        lambda *args: history.append(args),
+    )
+    return replies, history
+
+
+@pytest.mark.parametrize(
+    "agent_result",
+    [
+        pytest.param(
+            AgentMessageResult(text="[NO_RESPONSE]", should_reply=False),
+            id="agent-no-response",
+        ),
+        pytest.param(
+            AgentMessageResult(text="已達今日使用上限", should_reply=True),
+            id="usage-limit",
+        ),
+    ],
+)
+def test_process_line_message_task_skips_no_reply_results(monkeypatch, agent_result):
+    replies, history = _stub_line_task(monkeypatch, agent_result)
+
+    asyncio.run(
+        line_webhook.process_line_message_task(
+            "reply-token", "user-1", "hello", "chat-1", "1on1"
+        )
+    )
+
+    assert replies == []
+    assert history == []
+
+
+def test_process_line_message_task_replies_with_message_chunks(monkeypatch):
+    response = "x" * 2001
+    replies, history = _stub_line_task(
+        monkeypatch,
+        AgentMessageResult(text=response, should_reply=True),
+    )
+
+    asyncio.run(
+        line_webhook.process_line_message_task(
+            "reply-token", "user-1", "hello", "chat-1", "1on1"
+        )
+    )
+
+    assert len(replies) == 1
+    token, messages = replies[0]
+    assert token == "reply-token"
+    assert [message.text for message in messages] == ["x" * 2000, "x"]
+    assert history == [("user-1", "Alice", "hello", response, "LINE")]

--- a/tests/gateways/test_webhook_server.py
+++ b/tests/gateways/test_webhook_server.py
@@ -92,6 +92,29 @@ def test_webhook_status_reports_enabled_platforms():
     finally:
         webhook_server.configure_platforms("all")
 
+
+def test_entrypoint_initializes_dependencies_before_starting_server(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        webhook_server,
+        "initialize_dependencies",
+        lambda: calls.append(("initialize",)),
+    )
+    monkeypatch.setattr(
+        webhook_server.app,
+        "run",
+        lambda **kwargs: calls.append(("run", kwargs)),
+    )
+
+    webhook_server.entrypoint("line")
+
+    assert calls == [
+        ("initialize",),
+        ("run", {"host": "0.0.0.0", "port": 5190, "debug": False}),
+    ]
+    webhook_server.configure_platforms("all")
+
+
 def test_facebook_member_mapping_path_comes_from_config():
     assert facebook_webhook.MAPPING_FILE_PATH == MEMBER_MAPPING_FILE
     assert MEMBER_MAPPING_FILE.name == "member_mapping.csv"


### PR DESCRIPTION
## Summary

Add focused unit coverage for Facebook and LINE webhook routing, deduplication, and reply/no-reply decisions. Defer member-store initialization until webhook server startup so importing adapters in tests has no external sync side effect.

## Related Issue

Fixes #88

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Configuration or deployment
- [x] Tests

## Changes

- Cover Facebook processed-message cleanup, accepted routing, duplicate/echo/missing-mid skips, and CSV mapping outcomes.
- Cover Facebook no-response reaction behavior without Graph API calls.
- Cover LINE group whitelist, empty input, agent no-response, usage-limit, and chunked reply behavior without LINE API calls.
- Move webhook member-store initialization from module import to `entrypoint()` and verify startup ordering.

## Testing

- [x] Local tests or checks pass: `make test` (216 passed)
- [x] Manual verification completed: focused webhook tests (23 passed), `make precommit`, and `git diff --check`
- [ ] Not tested; reason:

## Impact Checklist

- [ ] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [x] Webhook behavior checked, if affected
- [ ] Docker or compose changes checked, if affected
- [ ] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

## Notes for Reviewers

The review found that importing `webhook_server` initialized the member store and could start a real background sync during tests. Initialization now runs from the server entrypoint, preserving runtime behavior while keeping imports deterministic. Facebook Graph, LINE SDK/network sends, and agent/LLM calls are mocked or guarded in every new test.
