### PR TITLE
[Observability]: Standardize gateway and job event logs

### DIFF
--- a/src/ian/gateways/discord_bot.py
+++ b/src/ian/gateways/discord_bot.py
@@ -20,6 +20,7 @@
 
 import os
 import json
+import time
 import discord
 from discord.ext import commands
 from discord import app_commands
@@ -33,9 +34,14 @@ from ian.services.agent import (
     clear_session,
 )
 from ian.services.member_store import get_member_role as get_member_role_from_db, init as init_member_db
+from ian.utils.logging import elapsed_ms, hash_identifier, log_event
 
 UPLOAD_DIR = "uploads"
 CHAT_HISTORY_FILE = os.path.join(UPLOAD_DIR, "chat_history.jsonl")
+
+
+def _interaction_correlation_id(interaction: discord.Interaction) -> str:
+    return hash_identifier(getattr(interaction, "id", None) or interaction.user.id)
 
 
 def save_chat_history(sender_id, user_name, user_message, bot_response):
@@ -55,7 +61,16 @@ def save_chat_history(sender_id, user_name, user_message, bot_response):
         with open(CHAT_HISTORY_FILE, "a", encoding="utf-8") as f:
             f.write(json.dumps(new_entry, ensure_ascii=False) + "\n")
     except Exception as e:
-        print(f"Error saving chat history: {e}")
+        log_event(
+            "job_failed",
+            "discord_bot",
+            level="error",
+            platform="Discord",
+            status="error",
+            job="save_chat_history",
+            sender_id=sender_id,
+            error=e,
+        )
 
 
 # FAQ 按鈕視圖
@@ -64,6 +79,8 @@ class FAQView(discord.ui.View):
         super().__init__(timeout=None)
 
     async def ask_llm(self, interaction: discord.Interaction, prompt: str):
+        started_at = time.monotonic()
+        correlation_id = _interaction_correlation_id(interaction)
         await interaction.response.defer(ephemeral=True)
 
         user = interaction.user
@@ -73,7 +90,27 @@ class FAQView(discord.ui.View):
 
         current_time = get_current_time()
 
+        log_event(
+            "request_received",
+            "discord_bot",
+            platform="Discord",
+            status="accepted",
+            correlation_id=correlation_id,
+            interaction_id=getattr(interaction, "id", None),
+            user_id=str(user.id),
+            channel_id=str(interaction.channel_id),
+            source="faq",
+            message_length=len(prompt),
+        )
         try:
+            log_event(
+                "agent_invoked",
+                "discord_bot",
+                platform="Discord",
+                status="started",
+                correlation_id=correlation_id,
+                user_id=str(user.id),
+            )
             agent_result = await run_agent_message_flow(
                 session_id=user.name,
                 user_name=user.display_name,
@@ -85,15 +122,43 @@ class FAQView(discord.ui.View):
                 account_id=str(user.id),
             )
             if not agent_result.should_reply:
-                print("Discord: Agent 決定不回覆此訊息")
+                log_event(
+                    "no_response",
+                    "discord_bot",
+                    platform="Discord",
+                    status="success",
+                    duration_ms=elapsed_ms(started_at),
+                    correlation_id=correlation_id,
+                    user_id=str(user.id),
+                    reason="agent_decision",
+                )
                 if agent_result.reaction_emoji:
                     await interaction.followup.send(agent_result.reaction_emoji)
                 return
             await interaction.followup.send(agent_result.text)
+            log_event(
+                "reply_sent",
+                "discord_bot",
+                platform="Discord",
+                status="success",
+                duration_ms=elapsed_ms(started_at),
+                correlation_id=correlation_id,
+                user_id=str(user.id),
+            )
 
         except Exception as e:
             await interaction.followup.send("⚠️ Error.")
-            print(f"Error processing FAQ button: {e}")
+            log_event(
+                "request_failed",
+                "discord_bot",
+                level="error",
+                platform="Discord",
+                status="error",
+                duration_ms=elapsed_ms(started_at),
+                correlation_id=correlation_id,
+                user_id=str(user.id),
+                error=e,
+            )
 
     @discord.ui.button(
         label="社課時間？", style=discord.ButtonStyle.secondary, custom_id="faq_time"
@@ -126,9 +191,23 @@ class FAQView(discord.ui.View):
 # Initialize member database
 try:
     init_member_db()
-    print("社員資料庫已初始化 (discord_chatbot)")
+    log_event(
+        "job_completed",
+        "discord_bot",
+        platform="Discord",
+        status="success",
+        job="member_store_initialization",
+    )
 except Exception as e:
-    print(f"社員資料庫初始化失敗: {e}")
+    log_event(
+        "job_failed",
+        "discord_bot",
+        level="error",
+        platform="Discord",
+        status="error",
+        job="member_store_initialization",
+        error=e,
+    )
 
 intents = discord.Intents.default()
 intents.message_content = True
@@ -139,11 +218,19 @@ async def on_ready():
     await bot.tree.sync()
     start_log_processor()
     send_startup_notification()
-    print(f"Bot 已上線：{bot.user}")
+    log_event(
+        "service_ready",
+        "discord_bot",
+        platform="Discord",
+        status="ready",
+        service="discord_bot",
+    )
 
 @bot.tree.command(name="ask", description="Ask Avatar.")
 @app_commands.describe(prompt="歡迎詢問 NTUAI! Ask anything about NTUAI!")
 async def ask(interaction: discord.Interaction, prompt: str):
+    started_at = time.monotonic()
+    correlation_id = _interaction_correlation_id(interaction)
     user = interaction.user
 
     db_role = get_member_role_from_db("Discord", str(user.id))
@@ -152,12 +239,28 @@ async def ask(interaction: discord.Interaction, prompt: str):
     current_time = get_current_time()
     await interaction.response.defer()
 
-    print(
-        f"\n---\n{current_time['nowdatetime']} {interaction.channel} ({interaction.channel_id})\n"
-        f"{user.display_name} ({user.global_name}, {user.name}, {roles})\n詢問：{prompt}\n"
+    log_event(
+        "request_received",
+        "discord_bot",
+        platform="Discord",
+        status="accepted",
+        correlation_id=correlation_id,
+        interaction_id=getattr(interaction, "id", None),
+        user_id=str(user.id),
+        channel_id=str(interaction.channel_id),
+        source="slash_command",
+        message_length=len(prompt),
     )
 
     try:
+        log_event(
+            "agent_invoked",
+            "discord_bot",
+            platform="Discord",
+            status="started",
+            correlation_id=correlation_id,
+            user_id=str(user.id),
+        )
         agent_result = await run_agent_message_flow(
             session_id=user.name,
             user_name=user.display_name,
@@ -169,17 +272,44 @@ async def ask(interaction: discord.Interaction, prompt: str):
             account_id=str(user.id),
         )
         if not agent_result.should_reply:
-            print("Discord: Agent 決定不回覆此訊息")
+            log_event(
+                "no_response",
+                "discord_bot",
+                platform="Discord",
+                status="success",
+                duration_ms=elapsed_ms(started_at),
+                correlation_id=correlation_id,
+                user_id=str(user.id),
+                reason="agent_decision",
+            )
             if agent_result.reaction_emoji:
                 await interaction.followup.send(agent_result.reaction_emoji)
             return
         await interaction.followup.send(agent_result.text)
         save_chat_history(user.name, user.display_name, prompt, agent_result.text)
-        print("Message processed successfully")
+        log_event(
+            "reply_sent",
+            "discord_bot",
+            platform="Discord",
+            status="success",
+            duration_ms=elapsed_ms(started_at),
+            correlation_id=correlation_id,
+            user_id=str(user.id),
+        )
 
     except Exception as e:
         await interaction.followup.send("⚠️ Error.")
-        print(f"Error processing message: {e}")
+        log_event(
+            "request_failed",
+            "discord_bot",
+            level="error",
+            platform="Discord",
+            status="error",
+            duration_ms=elapsed_ms(started_at),
+            correlation_id=correlation_id,
+            user_id=str(user.id),
+            error=e,
+        )
 
 @bot.tree.command(name="faq", description="常見問題")
 async def faq(interaction: discord.Interaction):
@@ -189,15 +319,34 @@ async def faq(interaction: discord.Interaction):
 
 @bot.tree.command(name="clear", description="清除記憶")
 async def clear(interaction: discord.Interaction):
+    correlation_id = _interaction_correlation_id(interaction)
     try:
         await clear_session(interaction.user.name)
         await interaction.response.send_message("🫥 已清除記憶，請開始新的對話。\nCleared. Please start a new conversation.")
     except Exception as e:
         await interaction.response.send_message("⚠️ Error.")
-        print(f"Error clearing session: {e}")
+        log_event(
+            "request_failed",
+            "discord_bot",
+            level="error",
+            platform="Discord",
+            status="error",
+            correlation_id=correlation_id,
+            user_id=str(interaction.user.id),
+            operation="clear_session",
+            error=e,
+        )
 
 def entrypoint():
     if not DISCORD_BOT_TOKEN:
-        print("Error: DISCORD_BOT_TOKEN not found in environment variables.")
+        log_event(
+            "job_failed",
+            "discord_bot",
+            level="critical",
+            platform="Discord",
+            status="error",
+            job="bot_startup",
+            reason="missing_bot_token",
+        )
         raise SystemExit(1)
     bot.run(DISCORD_BOT_TOKEN)

--- a/src/ian/gateways/facebook_webhook.py
+++ b/src/ian/gateways/facebook_webhook.py
@@ -35,7 +35,7 @@ from ian.services.member_store import (
     get_member_name as get_member_name_from_db,
     get_member_role as get_member_role_from_db,
 )
-from ian.utils.console import eprint
+from ian.utils.logging import elapsed_ms, hash_identifier, log_event
 
 MAPPING_FILE_PATH = MEMBER_MAPPING_FILE
 
@@ -68,20 +68,48 @@ def get_member_mapping(username: str, csv_path: str):
         mapping = dict(zip(df[account_col], df["角色"]))
         return mapping.get(username.strip(), "非社員（尚未加入 AI 社）")
     except Exception as e:
-        print(f"讀取檔案失敗：{e}")
+        log_event(
+            "operation_failed",
+            "facebook_webhook",
+            level="error",
+            platform="Facebook",
+            status="error",
+            operation="load_member_mapping",
+            error=e,
+        )
         return "非社員"
 
 
-async def send_typing_indicator(recipient_id, action="typing_on"):
+async def send_typing_indicator(recipient_id, action="typing_on", correlation_id=None):
     url = f"https://graph.facebook.com/v18.0/me/messages?access_token={PAGE_ACCESS_TOKEN}"
     data = {"recipient": {"id": recipient_id}, "sender_action": action}
     headers = {"Content-Type": "application/json"}
     try:
         response = requests.post(url, headers=headers, json=data, timeout=3)
         if response.status_code != 200:
-            print(f"發送 FB 輸入狀態失敗: {response.text}")
+            log_event(
+                "external_send_failure",
+                "facebook_webhook",
+                level="warning",
+                platform="Facebook",
+                status="failure",
+                correlation_id=correlation_id,
+                recipient_id=recipient_id,
+                operation="typing_indicator",
+                http_status=response.status_code,
+            )
     except requests.exceptions.RequestException as e:
-        print(f"發送 FB 輸入狀態時連線失敗: {e}")
+        log_event(
+            "external_send_failure",
+            "facebook_webhook",
+            level="error",
+            platform="Facebook",
+            status="error",
+            correlation_id=correlation_id,
+            recipient_id=recipient_id,
+            operation="typing_indicator",
+            error=e,
+        )
 
 
 def get_fb_user_profile(sender_id):
@@ -94,26 +122,73 @@ def get_fb_user_profile(sender_id):
             full_name = f"{profile.get('first_name', '')} {profile.get('last_name', '')}".strip()
             return full_name
         else:
-            print(f"取得 FB 使用者資訊失敗: {response.text}")
+            log_event(
+                "external_send_failure",
+                "facebook_webhook",
+                level="warning",
+                platform="Facebook",
+                status="failure",
+                sender_id=sender_id,
+                operation="get_user_profile",
+                http_status=response.status_code,
+            )
             return None
     except requests.exceptions.RequestException as e:
-        print(f"連線 Facebook 失敗: {e}")
+        log_event(
+            "external_send_failure",
+            "facebook_webhook",
+            level="error",
+            platform="Facebook",
+            status="error",
+            sender_id=sender_id,
+            operation="get_user_profile",
+            error=e,
+        )
         return None
 
 
-def send_message(recipient_id, text):
+def send_message(recipient_id, text, correlation_id=None):
     url = f"https://graph.facebook.com/v18.0/me/messages?access_token={PAGE_ACCESS_TOKEN}"
     payload = {"recipient": {"id": recipient_id}, "message": {"text": text}}
     headers = {"Content-Type": "application/json"}
     try:
         response = requests.post(url, headers=headers, json=payload, timeout=10)
         if response.status_code != 200:
-            print(f"傳送 FB 訊息失敗: {response.text}")
+            log_event(
+                "external_send_failure",
+                "facebook_webhook",
+                level="warning",
+                platform="Facebook",
+                status="failure",
+                correlation_id=correlation_id,
+                recipient_id=recipient_id,
+                operation="send_message",
+                http_status=response.status_code,
+            )
+        else:
+            log_event(
+                "reply_sent",
+                "facebook_webhook",
+                platform="Facebook",
+                status="success",
+                correlation_id=correlation_id,
+                recipient_id=recipient_id,
+            )
     except requests.exceptions.RequestException as e:
-        print(f"發送 FB 訊息時連線失敗: {e}")
+        log_event(
+            "external_send_failure",
+            "facebook_webhook",
+            level="error",
+            platform="Facebook",
+            status="error",
+            correlation_id=correlation_id,
+            recipient_id=recipient_id,
+            operation="send_message",
+            error=e,
+        )
 
 
-def send_reaction(recipient_id, mid, emoji):
+def send_reaction(recipient_id, mid, emoji, correlation_id=None):
     """Send a reaction emoji to a specific message via FB Graph API."""
     url = f"https://graph.facebook.com/v18.0/me/messages?access_token={PAGE_ACCESS_TOKEN}"
     payload = {
@@ -128,16 +203,49 @@ def send_reaction(recipient_id, mid, emoji):
     try:
         response = requests.post(url, headers=headers, json=payload, timeout=10)
         if response.status_code != 200:
-            eprint(f"FB reaction 失敗: {response.text}")
+            log_event(
+                "external_send_failure",
+                "facebook_webhook",
+                level="warning",
+                platform="Facebook",
+                status="failure",
+                correlation_id=correlation_id,
+                recipient_id=recipient_id,
+                message_id=mid,
+                operation="send_reaction",
+                http_status=response.status_code,
+            )
         else:
-            eprint(f"FB reaction 成功: {emoji}")
+            log_event(
+                "reply_sent",
+                "facebook_webhook",
+                platform="Facebook",
+                status="success",
+                correlation_id=correlation_id,
+                recipient_id=recipient_id,
+                message_id=mid,
+                reply_type="reaction",
+            )
     except requests.exceptions.RequestException as e:
-        eprint(f"發送 FB reaction 時連線失敗: {e}")
+        log_event(
+            "external_send_failure",
+            "facebook_webhook",
+            level="error",
+            platform="Facebook",
+            status="error",
+            correlation_id=correlation_id,
+            recipient_id=recipient_id,
+            message_id=mid,
+            operation="send_reaction",
+            error=e,
+        )
 
 
 async def process_message_task(sender_id, user_message, mid=None):
+    correlation_id = hash_identifier(mid or sender_id)
+    started_at = time.monotonic()
     try:
-        await send_typing_indicator(sender_id, "typing_on")
+        await send_typing_indicator(sender_id, "typing_on", correlation_id)
         user_name = get_fb_user_profile(sender_id) or get_member_name_from_db("FB", sender_id) or "FB訪客"
         roles = get_member_role_from_db("FB", sender_id)
         account_id = sender_id
@@ -146,10 +254,16 @@ async def process_message_task(sender_id, user_message, mid=None):
             if csv_role != "非社員（尚未加入 AI 社）":
                 roles = csv_role
 
-        print(f"收到 FB [{roles}]/{user_name} ({sender_id}) 的訊息：{user_message}")
-        print(f"傳送給 agent 的身分資訊: {roles}")
-
         current_time = get_current_time()
+        log_event(
+            "agent_invoked",
+            "facebook_webhook",
+            platform="Facebook",
+            status="started",
+            correlation_id=correlation_id,
+            sender_id=sender_id,
+            message_length=len(user_message),
+        )
         agent_result = await run_agent_message_flow(
             session_id=sender_id,
             user_name=user_name,
@@ -161,21 +275,43 @@ async def process_message_task(sender_id, user_message, mid=None):
             account_id=account_id,
         )
 
-        await send_typing_indicator(sender_id, "typing_off")
+        await send_typing_indicator(sender_id, "typing_off", correlation_id)
 
         if not agent_result.should_reply:
-            eprint("FB: Agent 決定不回覆此訊息")
+            log_event(
+                "no_response",
+                "facebook_webhook",
+                platform="Facebook",
+                status="success",
+                duration_ms=elapsed_ms(started_at),
+                correlation_id=correlation_id,
+                sender_id=sender_id,
+                reason="agent_decision",
+            )
             if agent_result.reaction_emoji and mid:
-                send_reaction(sender_id, mid, agent_result.reaction_emoji)
+                send_reaction(sender_id, mid, agent_result.reaction_emoji, correlation_id)
             return
 
-        send_message(sender_id, agent_result.text)
+        send_message(sender_id, agent_result.text, correlation_id)
         save_chat_history(sender_id, user_name, user_message, agent_result.text, "FB")
-        print(f"FB 訊息處理完成並已回覆給 {user_name}")
 
     except Exception as e:
-        print(f"背景訊息處理任務發生錯誤 (FB, {sender_id}): {e}")
-        send_message(sender_id, "😰 Ian 目前有點忙碌，請稍後再試。\nIan is currently busy. Please try again later.")
+        log_event(
+            "request_failed",
+            "facebook_webhook",
+            level="error",
+            platform="Facebook",
+            status="error",
+            duration_ms=elapsed_ms(started_at),
+            correlation_id=correlation_id,
+            sender_id=sender_id,
+            error=e,
+        )
+        send_message(
+            sender_id,
+            "😰 Ian 目前有點忙碌，請稍後再試。\nIan is currently busy. Please try again later.",
+            correlation_id,
+        )
 
 
 def handle_facebook_messages(data):
@@ -192,12 +328,30 @@ def handle_facebook_messages(data):
 
                 with PROCESSED_MESSAGES_LOCK:
                     if mid in PROCESSED_MESSAGES:
-                        print(f"偵測到重複的訊息 ID (mid: {mid})，已略過。")
+                        log_event(
+                            "request_ignored",
+                            "facebook_webhook",
+                            platform="Facebook",
+                            status="duplicate",
+                            correlation_id=hash_identifier(mid),
+                            message_id=mid,
+                        )
                         continue
                     PROCESSED_MESSAGES[mid] = time.time()
 
                 sender_id = messaging_event["sender"]["id"]
                 user_message = message_obj["text"]
+
+                log_event(
+                    "request_received",
+                    "facebook_webhook",
+                    platform="Facebook",
+                    status="accepted",
+                    correlation_id=hash_identifier(mid),
+                    sender_id=sender_id,
+                    message_id=mid,
+                    message_length=len(user_message),
+                )
 
                 coro = process_message_task(sender_id, user_message, mid=mid)
                 thread = threading.Thread(target=asyncio.run, args=(coro,))

--- a/src/ian/gateways/line_webhook.py
+++ b/src/ian/gateways/line_webhook.py
@@ -20,6 +20,7 @@
 
 import asyncio
 import threading
+import time
 
 import requests
 from linebot import LineBotApi, WebhookHandler
@@ -32,14 +33,11 @@ from ian.gateways.messaging_common import (
     get_current_time,
     save_chat_history,
 )
-from ian.services.agent import (
-    add_log,
-)
 from ian.services.member_store import (
     get_member_name as get_member_name_from_db,
     get_member_role as get_member_role_from_db,
 )
-from ian.utils.console import eprint
+from ian.utils.logging import elapsed_ms, hash_identifier, log_event
 
 line_bot_api = LineBotApi(LINE_CHANNEL_ACCESS_TOKEN)
 line_handler = WebhookHandler(LINE_CHANNEL_SECRET)
@@ -51,7 +49,16 @@ def get_line_user_profile(user_id):
         profile = line_bot_api.get_profile(user_id)
         return profile.display_name
     except Exception as e:
-        print(f"取得 LINE 使用者資訊失敗: {e}")
+        log_event(
+            "external_send_failure",
+            "line_webhook",
+            level="error",
+            platform="LINE",
+            status="error",
+            user_id=user_id,
+            operation="get_user_profile",
+            error=e,
+        )
         return get_member_name_from_db("LINE", user_id) or f"LINE_{user_id[:8]}"
 
 
@@ -73,7 +80,15 @@ def handle_line_message(event):
         chat_id = event.source.user_id
 
     if source_type != "1on1" and chat_id not in LINE_ALLOWED_GROUPS:
-        eprint(f"LINE: 來源 {chat_id} 不在白名單中，忽略")
+        log_event(
+            "request_ignored",
+            "line_webhook",
+            platform="LINE",
+            status="unauthorized",
+            correlation_id=hash_identifier(event.reply_token),
+            user_id=user_id,
+            channel_id=chat_id,
+        )
         return
 
     actual_question = user_text.strip()
@@ -82,7 +97,17 @@ def handle_line_message(event):
         line_bot_api.reply_message(event.reply_token, TextSendMessage(text="請輸入您的問題！"))
         return
 
-    eprint(f"LINE: [{source_type}:{chat_id}] 收到 {user_id} 的訊息: {actual_question}")
+    log_event(
+        "request_received",
+        "line_webhook",
+        platform="LINE",
+        status="accepted",
+        correlation_id=hash_identifier(event.reply_token),
+        user_id=user_id,
+        channel_id=chat_id,
+        source_type=source_type,
+        message_length=len(actual_question),
+    )
 
     try:
         loading_url = "https://api.line.me/v2/bot/chat/loading/start"
@@ -96,7 +121,17 @@ def handle_line_message(event):
         }
         requests.post(loading_url, headers=headers, json=loading_data, timeout=3)
     except Exception as e:
-        eprint(f"LINE: 載入動畫啟動失敗: {e}")
+        log_event(
+            "external_send_failure",
+            "line_webhook",
+            level="error",
+            platform="LINE",
+            status="error",
+            correlation_id=hash_identifier(event.reply_token),
+            channel_id=chat_id,
+            operation="loading_indicator",
+            error=e,
+        )
 
     coro = process_line_message_task(event.reply_token, user_id, actual_question, chat_id, source_type)
     thread = threading.Thread(target=asyncio.run, args=(coro,))
@@ -105,6 +140,8 @@ def handle_line_message(event):
 
 async def process_line_message_task(reply_token, user_id, user_message, chat_id, source_type="group"):
     """LINE 訊息背景處理任務。"""
+    correlation_id = hash_identifier(reply_token)
+    started_at = time.monotonic()
     try:
         user_name = get_line_user_profile(user_id)
         if source_type == "1on1":
@@ -112,9 +149,17 @@ async def process_line_message_task(reply_token, user_id, user_message, chat_id,
         else:
             roles = "社員"
 
-        eprint(f"LINE: 處理 {user_name} 的訊息：{user_message}")
-
         current_time = get_current_time()
+        log_event(
+            "agent_invoked",
+            "line_webhook",
+            platform="LINE",
+            status="started",
+            correlation_id=correlation_id,
+            user_id=user_id,
+            channel_id=chat_id,
+            message_length=len(user_message),
+        )
         agent_result = await run_agent_message_flow(
             session_id=user_id,
             user_name=user_name,
@@ -127,11 +172,29 @@ async def process_line_message_task(reply_token, user_id, user_message, chat_id,
         )
 
         if not agent_result.should_reply:
-            eprint("LINE: Agent 決定不回覆此訊息")
+            log_event(
+                "no_response",
+                "line_webhook",
+                platform="LINE",
+                status="success",
+                duration_ms=elapsed_ms(started_at),
+                correlation_id=correlation_id,
+                user_id=user_id,
+                reason="agent_decision",
+            )
             return
 
         if "已達今日使用上限" in agent_result.text:
-            eprint("LINE: 使用者已達上限，不回覆")
+            log_event(
+                "no_response",
+                "line_webhook",
+                platform="LINE",
+                status="rate_limited",
+                duration_ms=elapsed_ms(started_at),
+                correlation_id=correlation_id,
+                user_id=user_id,
+                reason="usage_limit",
+            )
             return
 
         line_messages = []
@@ -142,20 +205,45 @@ async def process_line_message_task(reply_token, user_id, user_message, chat_id,
         if line_messages:
             try:
                 line_bot_api.reply_message(reply_token, line_messages)
-                eprint(f"LINE: reply_message 成功 -> chat_id={chat_id}, 訊息數={len(line_messages)}")
+                log_event(
+                    "reply_sent",
+                    "line_webhook",
+                    platform="LINE",
+                    status="success",
+                    duration_ms=elapsed_ms(started_at),
+                    correlation_id=correlation_id,
+                    user_id=user_id,
+                    channel_id=chat_id,
+                    message_count=len(line_messages),
+                )
             except Exception as reply_err:
-                eprint(f"LINE: reply_message 失敗 -> chat_id={chat_id}, 錯誤: {reply_err}")
-                import traceback
-
-                eprint(traceback.format_exc())
+                log_event(
+                    "external_send_failure",
+                    "line_webhook",
+                    level="error",
+                    platform="LINE",
+                    status="error",
+                    duration_ms=elapsed_ms(started_at),
+                    correlation_id=correlation_id,
+                    user_id=user_id,
+                    channel_id=chat_id,
+                    operation="reply_message",
+                    error=reply_err,
+                )
                 return
 
         save_chat_history(user_id, user_name, user_message, agent_result.text, "LINE")
-        eprint(f"LINE: 訊息處理完成並已回覆給 {user_name}")
 
     except Exception as e:
-        eprint(f"LINE: 背景訊息處理任務發生錯誤: {e}")
-        import traceback
-
-        eprint(traceback.format_exc())
-        add_log("ERROR", error=str(e), context=f"LINE message processing for {user_id} in {chat_id}")
+        log_event(
+            "request_failed",
+            "line_webhook",
+            level="error",
+            platform="LINE",
+            status="error",
+            duration_ms=elapsed_ms(started_at),
+            correlation_id=correlation_id,
+            user_id=user_id,
+            channel_id=chat_id,
+            error=e,
+        )

--- a/src/ian/services/agent/callbacks.py
+++ b/src/ian/services/agent/callbacks.py
@@ -23,6 +23,7 @@ from typing import Any, Dict
 from langchain_core.callbacks import BaseCallbackHandler
 
 from ian.services.agent.logging import add_log
+from ian.utils.logging import redact_user_content
 
 
 def extract_text_from_output(output) -> str:
@@ -61,7 +62,11 @@ class DiscordLogCallbackHandler(BaseCallbackHandler):
     ) -> None:
         """工具開始執行時"""
         tool_name = serialized.get("name", "unknown_tool")
-        add_log("TOOL_CALL", tool_name=tool_name, args=input_str)
+        add_log(
+            "TOOL_CALL",
+            tool_name=tool_name,
+            args=redact_user_content(input_str),
+        )
 
     def on_tool_end(
         self,
@@ -70,7 +75,11 @@ class DiscordLogCallbackHandler(BaseCallbackHandler):
     ) -> None:
         """工具執行完成時"""
         tool_name = kwargs.get("name", "tool")
-        add_log("TOOL_RESULT", tool_name=tool_name, result=output)
+        add_log(
+            "TOOL_RESULT",
+            tool_name=tool_name,
+            result=redact_user_content(str(output)),
+        )
         self.tool_results.append(extract_text_from_output(output))
 
     def on_tool_error(
@@ -79,4 +88,4 @@ class DiscordLogCallbackHandler(BaseCallbackHandler):
         **kwargs: Any,
     ) -> None:
         """工具執行錯誤時"""
-        add_log("ERROR", error=str(error), context="Tool execution")
+        add_log("ERROR", error=type(error).__name__, context="Tool execution")

--- a/src/ian/services/agent/logging.py
+++ b/src/ian/services/agent/logging.py
@@ -25,7 +25,7 @@ from queue import Queue
 
 from ian.config import DISCORD_LOG_CHANNEL_ID_INT
 from ian.services import discord_api
-from ian.utils.console import eprint
+from ian.utils.logging import log_event
 
 LOG_CHANNEL_ID = DISCORD_LOG_CHANNEL_ID_INT
 log_queue: Queue = Queue()
@@ -40,7 +40,13 @@ def start_log_processor():
     log_processor_started = True
     thread = threading.Thread(target=_process_log_queue_sync, daemon=True)
     thread.start()
-    eprint(f"Discord log processor started, logging to channel {LOG_CHANNEL_ID}")
+    log_event(
+        "service_started",
+        "agent_logging",
+        status="running",
+        service="discord_log_processor",
+        channel_id=LOG_CHANNEL_ID,
+    )
 
 
 def send_startup_notification():
@@ -63,14 +69,36 @@ def send_startup_notification():
 
         response = discord_api.send_channel_message(LOG_CHANNEL_ID, message)
         if response.status_code != 200:
-            eprint(
-                "Failed to send startup notification: "
-                f"{response.status_code} - {response.text}"
+            log_event(
+                "external_send_failure",
+                "agent_logging",
+                level="warning",
+                platform="Discord",
+                status="failure",
+                channel_id=LOG_CHANNEL_ID,
+                operation="send_startup_notification",
+                http_status=response.status_code,
             )
         else:
-            eprint("Startup notification sent to Discord log channel")
+            log_event(
+                "reply_sent",
+                "agent_logging",
+                platform="Discord",
+                status="success",
+                channel_id=LOG_CHANNEL_ID,
+                operation="send_startup_notification",
+            )
     except Exception as e:
-        eprint(f"Failed to send startup notification: {e}")
+        log_event(
+            "external_send_failure",
+            "agent_logging",
+            level="error",
+            platform="Discord",
+            status="error",
+            channel_id=LOG_CHANNEL_ID,
+            operation="send_startup_notification",
+            error=e,
+        )
 
 
 def _process_log_queue_sync():
@@ -82,7 +110,14 @@ def _process_log_queue_sync():
                 _send_log_to_discord_sync(log_entry)
             time.sleep(0.5)
         except Exception as e:
-            eprint(f"Error processing log queue: {e}")
+            log_event(
+                "job_failed",
+                "agent_logging",
+                level="error",
+                status="error",
+                job="process_log_queue",
+                error=e,
+            )
 
 
 def _send_log_to_discord_sync(log_entry: dict):
@@ -94,9 +129,27 @@ def _send_log_to_discord_sync(log_entry: dict):
 
         response = discord_api.send_channel_message(LOG_CHANNEL_ID, message)
         if response.status_code != 200:
-            eprint(f"Failed to send log to Discord: {response.status_code} - {response.text}")
+            log_event(
+                "external_send_failure",
+                "agent_logging",
+                level="warning",
+                platform="Discord",
+                status="failure",
+                channel_id=LOG_CHANNEL_ID,
+                operation="send_agent_log",
+                http_status=response.status_code,
+            )
     except Exception as e:
-        eprint(f"Failed to send log to Discord: {e}")
+        log_event(
+            "external_send_failure",
+            "agent_logging",
+            level="error",
+            platform="Discord",
+            status="error",
+            channel_id=LOG_CHANNEL_ID,
+            operation="send_agent_log",
+            error=e,
+        )
 
 
 def format_log_message(log_entry: dict) -> str:

--- a/src/ian/services/agent/runtime.py
+++ b/src/ian/services/agent/runtime.py
@@ -21,7 +21,6 @@
 import asyncio
 import threading
 import time
-import traceback
 from concurrent.futures import Future
 from datetime import datetime, timedelta, timezone
 from queue import Queue
@@ -38,7 +37,7 @@ from ian.services.agent.callbacks import (
     DiscordLogCallbackHandler,
     extract_text_from_output,
 )
-from ian.services.agent.logging import add_log, eprint, start_log_processor
+from ian.services.agent.logging import add_log, start_log_processor
 from ian.services.agent.prompt import SYS_PROMPT
 from ian.services.agent.sessions import (
     clear_session_if_timeout,
@@ -50,6 +49,12 @@ from ian.services.agent.sessions import (
 )
 from ian.services.agent.usage import check_and_update_usage
 from ian.services.member_store import lookup_member_by_platform
+from ian.utils.logging import (
+    elapsed_ms,
+    hash_identifier,
+    log_event,
+    redact_user_content,
+)
 
 
 def _unwrap_exception(exc: BaseException) -> BaseException:
@@ -88,7 +93,14 @@ async def run_agentic_workflow():
     client = MultiServerMCPClient(mcp_config)
     google_api_key = GOOGLE_API_KEY
     if not google_api_key:
-        print("Error: GOOGLE_API_KEY not found in environment variables.")
+        log_event(
+            "job_failed",
+            "agent_runtime",
+            level="critical",
+            status="error",
+            job="agent_startup",
+            reason="missing_google_api_key",
+        )
     primary_llm = ChatGoogleGenerativeAI(
         model="gemini-3-flash-preview",
         google_api_key=google_api_key,
@@ -106,14 +118,18 @@ async def run_agentic_workflow():
             )
             if session_id is None:
                 break
+            invocation_started_at = time.monotonic()
+            correlation_id = hash_identifier(session_id)
 
             # Log 使用者訊息
-            add_log("USER_MESSAGE",
-                    user_name=user_name,
-                    user_role=str(user_role),
-                    message=question,
-                    session_id=session_id,
-                    platform=platform)
+            add_log(
+                "USER_MESSAGE",
+                user_name=hash_identifier(user_name),
+                user_role=str(user_role),
+                message=redact_user_content(question),
+                session_id=hash_identifier(session_id),
+                platform=platform,
+            )
 
             # 動態產生時間資訊
             tz_taipei = timezone(timedelta(hours=8))
@@ -136,7 +152,12 @@ async def run_agentic_workflow():
                     current_timestamp,
                 )
                 if was_created:
-                    add_log("SESSION", action="Created", user_name=user_name, session_id=session_id)
+                    add_log(
+                        "SESSION",
+                        action="Created",
+                        user_name=hash_identifier(user_name),
+                        session_id=hash_identifier(session_id),
+                    )
 
                 # Initialize or re-initialize agent if needed
                 if session.get("agent") is None:
@@ -148,8 +169,14 @@ async def run_agentic_workflow():
                         checkpointer=memory,
                     )
                     set_session_agent(session_id, agent, memory)
-                    print(
-                        f"Created agent for {session_id} ({user_name}) session in {nowdatetime}"
+                    log_event(
+                        "operation_completed",
+                        "agent_runtime",
+                        platform=platform,
+                        status="success",
+                        correlation_id=correlation_id,
+                        session_id=session_id,
+                        operation="create_session_agent",
                     )
 
             # Agent invocation (outside the lock for long-running I/O)
@@ -190,12 +217,38 @@ async def run_agentic_workflow():
                     if invoke_attempt > 0:
                         # 重建 agent 並重新取得 MCP 工具，以清除損壞的連線/對話歷史
                         root_cause = _unwrap_exception(last_invoke_error) if last_invoke_error else last_invoke_error
-                        add_log("RETRY", user_name=user_name, reason=f"Tool 執行錯誤，重試中 ({type(root_cause).__name__}: {root_cause})", attempt=invoke_attempt + 1)
-                        print(f"🔄 Tool 執行錯誤，第 {invoke_attempt + 1} 次重試 ({user_name})")
+                        add_log(
+                            "RETRY",
+                            user_name=hash_identifier(user_name),
+                            reason=f"Tool 執行錯誤，重試中 ({type(root_cause).__name__})",
+                            attempt=invoke_attempt + 1,
+                        )
+                        log_event(
+                            "agent_retry",
+                            "agent_runtime",
+                            level="warning",
+                            platform=platform,
+                            status="retrying",
+                            correlation_id=correlation_id,
+                            session_id=session_id,
+                            reason="invoke_error",
+                            attempt=invoke_attempt + 1,
+                            error=root_cause,
+                        )
                         try:
                             tools = await client.get_tools()
                         except Exception as mcp_err:
-                            print(f"⚠️ MCP 工具重新取得失敗: {mcp_err}，嘗試重建 client")
+                            log_event(
+                                "operation_failed",
+                                "agent_runtime",
+                                level="warning",
+                                platform=platform,
+                                status="retrying",
+                                correlation_id=correlation_id,
+                                session_id=session_id,
+                                operation="refresh_mcp_tools",
+                                error=mcp_err,
+                            )
                             client = MultiServerMCPClient(mcp_config)
                             tools = await client.get_tools()
                         memory = MemorySaver()
@@ -216,8 +269,23 @@ async def run_agentic_workflow():
                                 prev_results = log_callback.tool_results
                                 log_callback = DiscordLogCallbackHandler()
                                 log_callback.tool_results = prev_results  # 保留上次 tool 回傳的 URL
-                                add_log("RETRY", user_name=user_name, reason="URL 驗證失敗，重試中", attempt=attempt + 1)
-                                print(f"🔄 URL 驗證失敗，第 {attempt + 1} 次重試 ({user_name})")
+                                add_log(
+                                    "RETRY",
+                                    user_name=hash_identifier(user_name),
+                                    reason="URL 驗證失敗，重試中",
+                                    attempt=attempt + 1,
+                                )
+                                log_event(
+                                    "agent_retry",
+                                    "agent_runtime",
+                                    level="warning",
+                                    platform=platform,
+                                    status="retrying",
+                                    correlation_id=correlation_id,
+                                    session_id=session_id,
+                                    reason="url_validation",
+                                    attempt=attempt + 1,
+                                )
 
                             invoke_sys_content = sys_content
                             if attempt > 0:
@@ -275,29 +343,69 @@ async def run_agentic_workflow():
                             raise
                         last_invoke_error = invoke_error
                         root_cause = _unwrap_exception(invoke_error)
-                        add_log("ERROR", error=f"{type(root_cause).__name__}: {root_cause}", context=f"Tool execution for {user_name}")
-                        print(f"⚠️ ainvoke 錯誤 (attempt {invoke_attempt + 1}/{MAX_INVOKE_RETRIES}): {type(root_cause).__name__}: {root_cause}")
-                        traceback.print_exception(root_cause)
+                        add_log(
+                            "ERROR",
+                            error=type(root_cause).__name__,
+                            context="Tool execution",
+                        )
+                        log_event(
+                            "agent_retry",
+                            "agent_runtime",
+                            level="warning",
+                            platform=platform,
+                            status="failure",
+                            correlation_id=correlation_id,
+                            session_id=session_id,
+                            reason="invoke_error",
+                            attempt=invoke_attempt + 1,
+                            error=root_cause,
+                        )
                         if invoke_attempt >= MAX_INVOKE_RETRIES - 1:
                             # 所有重試都失敗，拋出讓外層處理
                             raise
 
                 fut.set_result(parsed_agent_response)
 
-                # Log Agent 回應
-                add_log("AGENT_RESPONSE", user_name=user_name, response=parsed_agent_response)
-
-                print(
-                    f"✅ Agent 回應給 {user_name} ({user_role}): {parsed_agent_response}..."
+                log_event(
+                    "agent_completed",
+                    "agent_runtime",
+                    platform=platform,
+                    status="success",
+                    duration_ms=elapsed_ms(invocation_started_at),
+                    correlation_id=correlation_id,
+                    session_id=session_id,
+                    account_id=account_id,
                 )
+
+                # Log Agent 回應
+                add_log(
+                    "AGENT_RESPONSE",
+                    user_name=hash_identifier(user_name),
+                    response=redact_user_content(parsed_agent_response),
+                )
+
             except BaseException as error_msg:
                 if isinstance(error_msg, (KeyboardInterrupt, SystemExit)):
                     raise
                 # Log 錯誤（展開 ExceptionGroup 以顯示真正的根因）
                 root_cause = _unwrap_exception(error_msg)
-                add_log("ERROR", error=f"{type(root_cause).__name__}: {root_cause}", context=f"LLM invoke for {user_name}")
-                print(f"Error happened on llm invoke: {type(root_cause).__name__}: {root_cause}")
-                traceback.print_exception(root_cause)
+                add_log(
+                    "ERROR",
+                    error=type(root_cause).__name__,
+                    context="LLM invoke",
+                )
+                log_event(
+                    "agent_failed",
+                    "agent_runtime",
+                    level="error",
+                    platform=platform,
+                    status="error",
+                    duration_ms=elapsed_ms(invocation_started_at),
+                    correlation_id=correlation_id,
+                    session_id=session_id,
+                    account_id=account_id,
+                    error=root_cause,
+                )
                 # 重置 session，避免殘留的 AIMessage（帶 tool_calls 但無 ToolMessage）
                 # 導致後續請求因 INVALID_CHAT_HISTORY 持續失敗
                 with sessions_lock:
@@ -324,11 +432,23 @@ def start_dispatcher(user_name: str, current_time):
             t = threading.Thread(target=lambda: loop.run_forever(), daemon=True)
             t.start()
             asyncio.run_coroutine_threadsafe(run_agentic_workflow(), loop)
-            print(f"事件循環線程已啟動 (由 {user_name} 觸發)")
+            log_event(
+                "service_started",
+                "agent_runtime",
+                status="running",
+                service="agent_dispatcher",
+            )
             dispatcher_started = True
             return loop_agent
         except Exception as error:
-            print(f"Error starting dispatcher: {error}")
+            log_event(
+                "job_failed",
+                "agent_runtime",
+                level="error",
+                status="error",
+                job="start_dispatcher",
+                error=error,
+            )
 
 
 async def chat_with_agent(
@@ -344,14 +464,45 @@ async def chat_with_agent(
 
     # Prompt injection guardrail — check before anything else
     if detect_prompt_injection(question):
-        add_log("ERROR", error="Prompt injection blocked", context=f"{user_name} ({platform}): {question[:200]}")
-        eprint(f"🛡️ Prompt injection blocked from {user_name} ({platform})")
+        add_log("ERROR", error="Prompt injection blocked", context=f"{platform} request")
+        log_event(
+            "request_rejected",
+            "agent_runtime",
+            level="warning",
+            platform=platform,
+            status="blocked",
+            correlation_id=hash_identifier(session_id),
+            session_id=session_id,
+            account_id=account_id,
+            reason="prompt_injection",
+            message_length=len(question),
+        )
         return INJECTION_REJECTION_MSG
 
     # Check usage limit before processing
     if not check_and_update_usage(session_id):
+        log_event(
+            "no_response",
+            "agent_runtime",
+            platform=platform,
+            status="rate_limited",
+            correlation_id=hash_identifier(session_id),
+            session_id=session_id,
+            account_id=account_id,
+            reason="usage_limit",
+        )
         return "😌 已達今日使用上限，明天再來和我聊天吧！\nYou have reached the usage limit for today. Please come back and chat with me tomorrow!"
 
     fut = Future()
+    log_event(
+        "agent_invoked",
+        "agent_runtime",
+        platform=platform,
+        status="queued",
+        correlation_id=hash_identifier(session_id),
+        session_id=session_id,
+        account_id=account_id,
+        message_length=len(question),
+    )
     request_queue.put((session_id, user_name, question, user_role, timestamp, channel_id, platform, account_id, fut))
     return await asyncio.wrap_future(fut)

--- a/src/ian/services/agent/sessions.py
+++ b/src/ian/services/agent/sessions.py
@@ -20,6 +20,8 @@
 
 import threading
 
+from ian.utils.logging import log_event
+
 TIMEOUT_SECONDS = 900
 
 sessions: dict[str, dict] = {}
@@ -31,12 +33,20 @@ def clear_session_if_timeout(session_id: str, current_timestamp: float):
     if session_id in sessions:
         last_time = sessions[session_id].get("last_interaction_time")
         if last_time and (current_timestamp - last_time > TIMEOUT_SECONDS):
-            user_name = sessions[session_id].get("user_name", "unknown")
             sessions.pop(session_id)
-            print(f"Session {session_id} ({user_name}) timed out and was cleared.")
+            log_event(
+                "session_expired",
+                "agent_sessions",
+                status="cleared",
+                session_id=session_id,
+            )
         elif not last_time:
-            print(
-                f"Warning: Session {session_id} found without last_interaction_time during timeout check."
+            log_event(
+                "session_invalid",
+                "agent_sessions",
+                level="warning",
+                status="missing_timestamp",
+                session_id=session_id,
             )
 
 
@@ -57,13 +67,23 @@ def upsert_session(
             "channel_id": channel_id,
             "last_interaction_time": current_timestamp,
         }
-        print(f"Initialized session for {session_id} ({user_name}) at {current_timestamp}")
+        log_event(
+            "session_created",
+            "agent_sessions",
+            status="success",
+            session_id=session_id,
+        )
         return sessions[session_id], True
 
     sessions[session_id]["last_interaction_time"] = current_timestamp
     sessions[session_id]["user_name"] = user_name
     sessions[session_id]["channel_id"] = channel_id
-    print(f"Updated session for {session_id} ({user_name}) at {current_timestamp}")
+    log_event(
+        "session_updated",
+        "agent_sessions",
+        status="success",
+        session_id=session_id,
+    )
     return sessions[session_id], False
 
 
@@ -83,15 +103,31 @@ def reset_session_agent(session_id: str, user_name: str):
     if session_id in sessions:
         sessions[session_id]["agent"] = None
         sessions[session_id]["memory"] = None
-        print(f"🔄 已重置 session {session_id} ({user_name}) 以清除損壞的對話歷史")
+        log_event(
+            "session_reset",
+            "agent_sessions",
+            level="warning",
+            status="success",
+            session_id=session_id,
+            reason="invalid_chat_history",
+        )
 
 
 async def clear_session(session_id: str):
     """手動清除指定 session（例如使用者執行 /clear）。"""
     with sessions_lock:
         if session_id in sessions:
-            user_name = sessions[session_id].get("user_name", "unknown")
             sessions.pop(session_id)
-            print(f"Session {session_id} ({user_name}) has been manually cleared.")
+            log_event(
+                "session_cleared",
+                "agent_sessions",
+                status="success",
+                session_id=session_id,
+            )
         else:
-            print(f"Session {session_id} not found, cannot clear.")
+            log_event(
+                "session_clear_skipped",
+                "agent_sessions",
+                status="not_found",
+                session_id=session_id,
+            )

--- a/src/ian/services/agent/usage.py
+++ b/src/ian/services/agent/usage.py
@@ -21,6 +21,8 @@
 import threading
 from datetime import datetime, timedelta, timezone
 
+from ian.utils.logging import log_event
+
 DAILY_LIMIT = 10
 
 usage_tracker = {}
@@ -34,13 +36,35 @@ def check_and_update_usage(user_id: str) -> bool:
 
         if not user_data or user_data.get("date") != today_str:
             usage_tracker[user_id] = {"date": today_str, "count": 1}
-            print(f"Usage Tracking: New day/user '{user_id}'. Count: 1")
+            log_event(
+                "usage_updated",
+                "agent_usage",
+                status="allowed",
+                user_id=user_id,
+                usage_count=1,
+                usage_limit=DAILY_LIMIT,
+            )
             return True
 
         if user_data["count"] < DAILY_LIMIT:
             user_data["count"] += 1
-            print(f"Usage Tracking: User '{user_id}'. Count: {user_data['count']}")
+            log_event(
+                "usage_updated",
+                "agent_usage",
+                status="allowed",
+                user_id=user_id,
+                usage_count=user_data["count"],
+                usage_limit=DAILY_LIMIT,
+            )
             return True
 
-        print(f"Usage Tracking: User '{user_id}' has reached the daily limit of {DAILY_LIMIT}.")
+        log_event(
+            "usage_limit_reached",
+            "agent_usage",
+            level="warning",
+            status="rate_limited",
+            user_id=user_id,
+            usage_count=user_data["count"],
+            usage_limit=DAILY_LIMIT,
+        )
         return False

--- a/src/ian/services/member_store.py
+++ b/src/ian/services/member_store.py
@@ -36,7 +36,7 @@ from ian.domain.members import (
 )
 from ian.services.member_api import MemberApiError, fetch_members, update_member_fields
 from ian.services.member_cache import MemberCache
-from ian.utils.console import eprint
+from ian.utils.logging import elapsed_ms, log_event
 
 
 # ---------------------------------------------------------------------------
@@ -49,19 +49,37 @@ _cache = MemberCache(MEMBER_DB_FILE)
 # ---------------------------------------------------------------------------
 def sync_member_data() -> bool:
     """Fetch latest member data from API and save to local file."""
+    started_at = time.monotonic()
+    log_event(
+        "job_started",
+        "member_store",
+        status="started",
+        job="member_sync",
+    )
     try:
-        eprint("[MemberDB] Syncing member data from API...")
         data = fetch_members(MEMBER_API_URL, MEMBER_API_KEY)
         _cache.replace_all(data)
         _cache.save()
 
-        eprint(f"[MemberDB] Synced {len(data)} members successfully")
+        log_event(
+            "job_completed",
+            "member_store",
+            status="success",
+            duration_ms=elapsed_ms(started_at),
+            job="member_sync",
+            member_count=len(data),
+        )
         return True
-    except MemberApiError as e:
-        eprint(f"[MemberDB] Sync failed: {e}")
-        return False
     except Exception as e:
-        eprint(f"[MemberDB] Sync failed: {e}")
+        log_event(
+            "job_failed",
+            "member_store",
+            level="error",
+            status="error",
+            duration_ms=elapsed_ms(started_at),
+            job="member_sync",
+            error=e,
+        )
         return False
 
 
@@ -70,12 +88,32 @@ def load_member_db() -> bool:
     try:
         data = _cache.load()
         if data is None:
-            eprint("[MemberDB] Local DB file not found, attempting sync...")
+            log_event(
+                "operation_failed",
+                "member_store",
+                level="warning",
+                status="fallback",
+                operation="load_member_cache",
+                reason="file_not_found",
+            )
             return sync_member_data()
-        eprint(f"[MemberDB] Loaded {len(data)} members from local file")
+        log_event(
+            "operation_completed",
+            "member_store",
+            status="success",
+            operation="load_member_cache",
+            member_count=len(data),
+        )
         return True
     except Exception as e:
-        eprint(f"[MemberDB] Failed to load local DB: {e}")
+        log_event(
+            "operation_failed",
+            "member_store",
+            level="error",
+            status="error",
+            operation="load_member_cache",
+            error=e,
+        )
         return False
 
 
@@ -221,7 +259,15 @@ def bind_email(email: str, platform: str, account_id: str) -> dict:
     try:
         _cache.save()
     except Exception as e:
-        eprint(f"[MemberDB] Failed to save local DB after binding: {e}")
+        log_event(
+            "operation_failed",
+            "member_store",
+            level="error",
+            status="error",
+            operation="save_member_cache",
+            source="bind_email",
+            error=e,
+        )
 
     name = member.get("id", "")
     role = get_role_from_tier(member.get("Tier", ""))
@@ -262,7 +308,15 @@ def _update_member_field(email: str, field: str, value: str) -> dict:
     try:
         _cache.save()
     except Exception as e:
-        eprint(f"[MemberDB] Failed to save local DB after update: {e}")
+        log_event(
+            "operation_failed",
+            "member_store",
+            level="error",
+            status="error",
+            operation="save_member_cache",
+            source="update_member_field",
+            error=e,
+        )
 
     return {"success": True, "message": "更新成功"}
 
@@ -372,19 +426,36 @@ def start_daily_sync():
                     hour=0, minute=0, second=0, microsecond=0
                 )
                 wait_seconds = (tomorrow - now).total_seconds()
-                eprint(
-                    f"[MemberDB] Next sync in {wait_seconds:.0f}s "
-                    f"(at {tomorrow.strftime('%Y-%m-%d %H:%M:%S')} UTC+8)"
+                log_event(
+                    "job_scheduled",
+                    "member_store",
+                    status="scheduled",
+                    job="member_sync",
+                    wait_seconds=wait_seconds,
+                    next_run=tomorrow.isoformat(),
                 )
                 time.sleep(wait_seconds)
                 sync_member_data()
             except Exception as e:
-                eprint(f"[MemberDB] Scheduler error: {e}")
+                log_event(
+                    "job_failed",
+                    "member_store",
+                    level="error",
+                    status="error",
+                    job="member_sync",
+                    stage="scheduler_loop",
+                    error=e,
+                )
                 time.sleep(3600)  # Retry in 1 hour on error
 
     thread = threading.Thread(target=_scheduler_loop, daemon=True)
     thread.start()
-    eprint("[MemberDB] Daily sync scheduler started")
+    log_event(
+        "service_started",
+        "member_store",
+        status="running",
+        service="member_sync_scheduler",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -394,7 +465,14 @@ def init():
     """Initialize member DB: load from local file, sync from API, start scheduler."""
     loaded = load_member_db()
     if not loaded:
-        eprint("[MemberDB] Initial load failed, will retry on first lookup")
+        log_event(
+            "operation_failed",
+            "member_store",
+            level="warning",
+            status="retry_pending",
+            operation="initialize_member_store",
+            reason="initial_load_failed",
+        )
     # Always try to sync fresh data in background on startup
     threading.Thread(target=sync_member_data, daemon=True).start()
     start_daily_sync()

--- a/src/ian/services/rag.py
+++ b/src/ian/services/rag.py
@@ -23,6 +23,7 @@ import json
 import math
 import os
 import re
+import time
 from collections import Counter
 from functools import lru_cache
 from typing import Any, Dict, List, Tuple
@@ -35,7 +36,7 @@ from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 from ian.config import CACHE_DIR, DATA_DIR
-from ian.utils.console import eprint
+from ian.utils.logging import elapsed_ms, log_event
 
 
 vector_store = None
@@ -103,9 +104,23 @@ def load_jsonl_data(file_path: str) -> List[Dict[str, Any]]:
                 if line:
                     data.append(json.loads(line))
     except FileNotFoundError:
-        eprint(f"檔案不存在: {file_path}")
+        log_event(
+            "operation_failed",
+            "rag",
+            level="warning",
+            status="failure",
+            operation="load_jsonl",
+            reason="file_not_found",
+        )
     except Exception as e:
-        eprint(f"載入 JSONL 檔案錯誤: {e}")
+        log_event(
+            "operation_failed",
+            "rag",
+            level="error",
+            status="error",
+            operation="load_jsonl",
+            error=e,
+        )
     return data
 
 
@@ -115,10 +130,24 @@ def load_markdown_data(file_path: str) -> str:
         with open(file_path, "r", encoding="utf-8") as f:
             return f.read()
     except FileNotFoundError:
-        eprint(f"檔案不存在: {file_path}")
+        log_event(
+            "operation_failed",
+            "rag",
+            level="warning",
+            status="failure",
+            operation="load_markdown",
+            reason="file_not_found",
+        )
         return ""
     except Exception as e:
-        eprint(f"載入 Markdown 檔案錯誤: {e}")
+        log_event(
+            "operation_failed",
+            "rag",
+            level="error",
+            status="error",
+            operation="load_markdown",
+            error=e,
+        )
         return ""
 
 
@@ -293,7 +322,13 @@ def build_bm25_index():
         bm25_docs.append(doc)
 
     bm25_system = SimpleBM25(bm25_corpus)
-    eprint(f"BM25 索引建立完成: {len(bm25_corpus)} 個文檔")
+    log_event(
+        "operation_completed",
+        "rag",
+        status="success",
+        operation="build_bm25_index",
+        document_count=len(bm25_corpus),
+    )
 
 
 def bm25_search(query: str, top_k: int = 10) -> List[Tuple[Document, float]]:
@@ -407,10 +442,22 @@ def _try_load_faiss_index():
             embedding_model,
             allow_dangerous_deserialization=True,
         )
-        eprint("[快取] 從本地快取載入 FAISS 索引")
+        log_event(
+            "operation_completed",
+            "rag",
+            status="success",
+            operation="load_faiss_cache",
+        )
         return True
     except Exception as e:
-        eprint(f"[快取] 載入 FAISS 索引失敗: {e}")
+        log_event(
+            "operation_failed",
+            "rag",
+            level="warning",
+            status="failure",
+            operation="load_faiss_cache",
+            error=e,
+        )
         return False
 
 
@@ -418,9 +465,21 @@ def _save_faiss_index():
     try:
         os.makedirs(FAISS_INDEX_DIR, exist_ok=True)
         vector_store.save_local(FAISS_INDEX_DIR)
-        eprint("[快取] FAISS 索引已儲存到本地快取")
+        log_event(
+            "operation_completed",
+            "rag",
+            status="success",
+            operation="save_faiss_cache",
+        )
     except Exception as e:
-        eprint(f"[快取] 儲存 FAISS 索引失敗: {e}")
+        log_event(
+            "operation_failed",
+            "rag",
+            level="warning",
+            status="failure",
+            operation="save_faiss_cache",
+            error=e,
+        )
 
 
 def _try_move_faiss_to_gpu():
@@ -433,26 +492,69 @@ def _try_move_faiss_to_gpu():
             cpu_index = vector_store.index
             gpu_index = faiss_lib.index_cpu_to_gpu(gpu_res, 0, cpu_index)
             vector_store.index = gpu_index
-            eprint(f"[GPU] FAISS 索引已載入 GPU (共 {faiss_lib.get_num_gpus()} 個 GPU)")
+            log_event(
+                "operation_completed",
+                "rag",
+                status="success",
+                operation="move_faiss_to_gpu",
+                gpu_count=faiss_lib.get_num_gpus(),
+            )
             return True
-        eprint("[GPU] 未偵測到可用的 GPU，使用 CPU 模式")
+        log_event(
+            "operation_completed",
+            "rag",
+            status="cpu_fallback",
+            operation="move_faiss_to_gpu",
+            gpu_count=0,
+        )
         return False
     except Exception as e:
-        eprint(f"[GPU] 無法將 FAISS 索引移到 GPU: {e}")
+        log_event(
+            "operation_failed",
+            "rag",
+            level="warning",
+            status="failure",
+            operation="move_faiss_to_gpu",
+            error=e,
+        )
         return False
 
 
 def initialize_rag_system():
     global vector_store, embedding_model, documents
 
-    jieba.initialize()
+    started_at = time.monotonic()
+    log_event("job_started", "rag", status="started", job="rag_initialization")
+    try:
+        jieba.initialize()
+    except Exception as e:
+        log_event(
+            "job_failed",
+            "rag",
+            level="error",
+            status="error",
+            duration_ms=elapsed_ms(started_at),
+            job="rag_initialization",
+            stage="tokenizer",
+            error=e,
+        )
+        return False
+
     try:
         embedding_model = HuggingFaceEmbeddings(
             model_name="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
         )
-        eprint("多語言嵌入模型初始化完成")
     except Exception as e:
-        eprint(f"嵌入模型初始化失敗: {e}")
+        log_event(
+            "job_failed",
+            "rag",
+            level="error",
+            status="error",
+            duration_ms=elapsed_ms(started_at),
+            job="rag_initialization",
+            stage="embedding_model",
+            error=e,
+        )
         return False
 
     jsonl_file_path = str(DATA_DIR / "ntuai_recompiled_index.jsonl")
@@ -464,19 +566,22 @@ def initialize_rag_system():
         use_cache = (current_hash == saved_hash) and os.path.exists(FAISS_INDEX_DIR)
 
         if use_cache:
-            eprint(f"[快取] 來源檔案未變更 (hash: {current_hash[:8]}...)，嘗試載入快取")
             if _try_load_faiss_index():
                 jsonl_data = load_jsonl_data(jsonl_file_path)
                 md_content = load_markdown_data(md_file_path)
                 documents = create_enhanced_documents(jsonl_data, md_content)
                 build_bm25_index()
                 _try_move_faiss_to_gpu()
+                log_event(
+                    "job_completed",
+                    "rag",
+                    status="success",
+                    duration_ms=elapsed_ms(started_at),
+                    job="rag_initialization",
+                    source="cache",
+                    document_count=len(documents),
+                )
                 return True
-            eprint("[快取] 快取載入失敗，重建索引")
-        elif saved_hash:
-            eprint(f"[快取] 來源檔案已變更 (舊: {saved_hash[:8]}... → 新: {current_hash[:8]}...)，重建索引")
-        else:
-            eprint(f"[快取] 首次建立索引 (hash: {current_hash[:8]}...)")
 
         jsonl_data = load_jsonl_data(jsonl_file_path)
         md_content = load_markdown_data(md_file_path)
@@ -484,17 +589,43 @@ def initialize_rag_system():
 
         if documents:
             vector_store = FAISS.from_documents(documents, embedding_model)
-            eprint(f"向量資料庫建立完成, 包含 {len(documents)} 個文檔")
             _save_faiss_index()
             _save_hash(current_hash)
             build_bm25_index()
             _try_move_faiss_to_gpu()
+            log_event(
+                "job_completed",
+                "rag",
+                status="success",
+                duration_ms=elapsed_ms(started_at),
+                job="rag_initialization",
+                source="rebuilt",
+                document_count=len(documents),
+            )
             return True
 
-        eprint("沒有找到任何文檔資料")
+        log_event(
+            "job_failed",
+            "rag",
+            level="warning",
+            status="failure",
+            duration_ms=elapsed_ms(started_at),
+            job="rag_initialization",
+            stage="load_documents",
+            reason="no_documents",
+        )
         return False
     except Exception as e:
-        eprint(f"初始化過程發生錯誤: {e}")
+        log_event(
+            "job_failed",
+            "rag",
+            level="error",
+            status="error",
+            duration_ms=elapsed_ms(started_at),
+            job="rag_initialization",
+            stage="build_index",
+            error=e,
+        )
         return False
 
 

--- a/src/ian/services/reminder_runner.py
+++ b/src/ian/services/reminder_runner.py
@@ -21,13 +21,13 @@
 import json
 import io
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from urllib.parse import quote
 
 import pandas as pd
 import requests
 
-from ian.config import COURSE_DATA_URL, MEMBER_DB_FILE
+from ian.config import COURSE_DATA_URL, MEMBER_DB_FILE, TZ_TPE
 from ian.domain.reminders import (
     find_events_on_date,
     format_reminder_message,
@@ -35,12 +35,15 @@ from ian.domain.reminders import (
     seconds_until_next_run,
 )
 from ian.services.notifications import send_discord_dm, send_log
-from ian.utils.console import eprint
-
-TZ_TPE = timezone(timedelta(hours=8))
+from ian.utils.logging import elapsed_ms, log_event
 
 REMINDER_HOUR = 19
 REMINDER_MINUTE = 0
+_FAILURE_NOTIFICATIONS = {
+    "fetch_course_data": "FAILED to fetch course data",
+    "prepare_events": "FAILED to prepare event data",
+    "load_members": "FAILED to load member data",
+}
 
 
 def load_members() -> list[dict]:
@@ -59,52 +62,88 @@ def fetch_course_data() -> pd.DataFrame:
     return pd.read_csv(io.StringIO(resp.text))
 
 
+def _report_job_failure(
+    started_at: float,
+    target_date: str,
+    stage: str,
+    error: Exception,
+) -> None:
+    log_event(
+        "job_failed",
+        "reminder_runner",
+        level="error",
+        status="error",
+        duration_ms=elapsed_ms(started_at),
+        job="daily_reminder",
+        stage=stage,
+        target_date=target_date,
+        error=error,
+    )
+    send_log(f"```\n[REMINDER] {_FAILURE_NOTIFICATIONS[stage]}\n```")
+
+
 def run_once(target_date: str | None = None, dry: bool = False):
+    started_at = time.monotonic()
     now = datetime.now(TZ_TPE)
-    eprint(f"[Reminder] Started at {now.strftime('%Y-%m-%d %H:%M:%S')} UTC+8")
 
     if target_date is None:
         tomorrow = now + timedelta(days=1)
         target_date = tomorrow.strftime("%Y/%m/%d")
 
-    eprint(f"[Reminder] Checking events for: {target_date}")
+    log_event(
+        "job_started",
+        "reminder_runner",
+        status="started",
+        job="daily_reminder",
+        target_date=target_date,
+        dry_run=dry,
+    )
 
     try:
         df = fetch_course_data()
-        eprint(f"[Reminder] Loaded {len(df)} events from Google Sheets")
     except Exception as e:
-        eprint(f"[Reminder] Failed to fetch course data: {e}")
-        send_log(f"```\n[REMINDER] FAILED to fetch course data: {e}\n```")
+        _report_job_failure(started_at, target_date, "fetch_course_data", e)
         return
 
-    events = find_events_on_date(df, target_date)
+    try:
+        events = find_events_on_date(df, target_date)
+        message = format_reminder_message(events) if events else ""
+    except Exception as e:
+        _report_job_failure(started_at, target_date, "prepare_events", e)
+        return
+
     if not events:
-        eprint(f"[Reminder] No events on {target_date}, done.")
+        log_event(
+            "job_completed",
+            "reminder_runner",
+            status="success",
+            duration_ms=elapsed_ms(started_at),
+            job="daily_reminder",
+            target_date=target_date,
+            event_count=0,
+            recipient_count=0,
+        )
         return
-
-    eprint(f"[Reminder] Found {len(events)} event(s) on {target_date}:")
-    for ev in events:
-        eprint(f"  - {ev['title']} ({ev['time']})")
-
-    message = format_reminder_message(events)
-    eprint(f"\n[Reminder] Message:\n{message}\n")
 
     try:
         members = load_members()
         bound = get_valid_bound_members(members)
     except Exception as e:
-        eprint(f"[Reminder] Failed to load member data: {e}")
-        send_log(f"```\n[REMINDER] FAILED to load member data: {e}\n```")
+        _report_job_failure(started_at, target_date, "load_members", e)
         return
 
     if dry:
-        eprint("[Reminder] DRY RUN — no messages sent.")
-        eprint(f"[Reminder] Would notify {len(bound)} member(s):")
-        for m in bound:
-            eprint(f"  - {m['name']} (Discord)")
+        log_event(
+            "job_completed",
+            "reminder_runner",
+            status="dry_run",
+            duration_ms=elapsed_ms(started_at),
+            job="daily_reminder",
+            target_date=target_date,
+            event_count=len(events),
+            recipient_count=len(bound),
+        )
         return
-
-    eprint(f"[Reminder] Notifying {len(bound)} member(s)...")
 
     discord_ok, discord_fail = 0, 0
 
@@ -118,16 +157,23 @@ def run_once(target_date: str | None = None, dry: bool = False):
             personal_message += f"\n\n簽到碼連結：{checkin_url}"
 
         if m["discord_id"]:
-            eprint(f"  Sending Discord DM to {name}...")
             try:
                 if send_discord_dm(m["discord_id"], personal_message):
                     discord_ok += 1
-                    eprint(f"  [Discord] {name} OK")
                 else:
                     discord_fail += 1
             except Exception as e:
                 discord_fail += 1
-                eprint(f"  [Discord] {name} failed: {e}")
+                log_event(
+                    "external_send_failure",
+                    "reminder_runner",
+                    level="error",
+                    platform="Discord",
+                    status="error",
+                    recipient_id=m["discord_id"],
+                    operation="send_reminder",
+                    error=e,
+                )
             time.sleep(0.5)
 
     event_titles = ", ".join(ev["title"] for ev in events)
@@ -139,21 +185,49 @@ def run_once(target_date: str | None = None, dry: bool = False):
         f"Total members notified: {discord_ok}\n"
         f"```"
     )
-    eprint(f"\n{summary}")
+    log_event(
+        "job_completed",
+        "reminder_runner",
+        status="success" if discord_fail == 0 else "partial_failure",
+        duration_ms=elapsed_ms(started_at),
+        job="daily_reminder",
+        target_date=target_date,
+        event_count=len(events),
+        recipient_count=len(bound),
+        sent_count=discord_ok,
+        failed_count=discord_fail,
+    )
     send_log(summary)
 
 def daemon_loop():
-    eprint("[Reminder] Daemon mode started")
+    log_event(
+        "service_started",
+        "reminder_runner",
+        status="running",
+        service="reminder_daemon",
+    )
     while True:
         wait = seconds_until_next_run(hour=REMINDER_HOUR, minute=REMINDER_MINUTE)
         next_run = datetime.now(TZ_TPE) + timedelta(seconds=wait)
-        eprint(
-            f"[Reminder] Next run in {wait:.0f}s "
-            f"(at {next_run.strftime('%Y-%m-%d %H:%M:%S')} UTC+8)"
+        log_event(
+            "job_scheduled",
+            "reminder_runner",
+            status="scheduled",
+            job="daily_reminder",
+            wait_seconds=wait,
+            next_run=next_run.isoformat(),
         )
         time.sleep(wait)
         try:
             run_once()
         except Exception as e:
-            eprint(f"[Reminder] Error during run: {e}")
-            send_log(f"```\n[REMINDER] ERROR: {e}\n```")
+            log_event(
+                "job_failed",
+                "reminder_runner",
+                level="error",
+                status="error",
+                job="daily_reminder",
+                stage="daemon_loop",
+                error=e,
+            )
+            send_log("```\n[REMINDER] ERROR\n```")

--- a/src/ian/services/service_supervisor.py
+++ b/src/ian/services/service_supervisor.py
@@ -24,6 +24,8 @@ from collections.abc import Callable, Sequence
 from urllib.error import URLError
 from urllib.request import urlopen
 
+from ian.utils.logging import elapsed_ms, log_event
+
 
 Command = list[str]
 
@@ -72,26 +74,82 @@ def serve_all(
 ) -> int:
     commands = build_serve_commands(mcp_port=mcp_port)
     processes: list[subprocess.Popen] = []
+    started_at = time.monotonic()
 
     try:
-        print("Starting MCP server in HTTP mode...")
+        log_event(
+            "job_started",
+            "service_supervisor",
+            status="started",
+            job="serve_all",
+        )
         processes.append(popen_factory(commands[0]))
+        log_event(
+            "service_started",
+            "service_supervisor",
+            status="starting",
+            service="mcp",
+        )
 
-        print("Waiting for MCP server to initialize...")
+        log_event(
+            "health_wait_started",
+            "service_supervisor",
+            status="waiting",
+            service="mcp",
+            timeout_seconds=health_timeout,
+        )
         wait_for_http(f"http://localhost:{mcp_port}/health", health_timeout)
-        print("MCP server is ready!")
+        log_event(
+            "service_ready",
+            "service_supervisor",
+            status="ready",
+            service="mcp",
+        )
 
         for command in commands[1:]:
-            print(f"Starting {' '.join(command[1:])}...")
             processes.append(popen_factory(command))
+            log_event(
+                "service_started",
+                "service_supervisor",
+                status="starting",
+                service=command[1],
+            )
 
         while True:
-            for process in processes:
+            for index, process in enumerate(processes):
                 returncode = process.poll()
                 if returncode is not None:
+                    log_event(
+                        "job_failed",
+                        "service_supervisor",
+                        level="error",
+                        status="unexpected_exit",
+                        duration_ms=elapsed_ms(started_at),
+                        job="serve_all",
+                        service=commands[index][1],
+                        return_code=returncode,
+                    )
                     return returncode
             sleep(1)
     except KeyboardInterrupt:
+        log_event(
+            "job_completed",
+            "service_supervisor",
+            status="interrupted",
+            duration_ms=elapsed_ms(started_at),
+            job="serve_all",
+        )
         return 130
+    except Exception as e:
+        log_event(
+            "job_failed",
+            "service_supervisor",
+            level="error",
+            status="error",
+            duration_ms=elapsed_ms(started_at),
+            job="serve_all",
+            error=e,
+        )
+        raise
     finally:
         stop_processes(processes)

--- a/src/ian/utils/logging.py
+++ b/src/ian/utils/logging.py
@@ -24,6 +24,7 @@ import hashlib
 import json
 import sys
 import threading
+import time
 from collections.abc import Callable, Mapping
 from datetime import datetime
 from typing import Any, TextIO
@@ -39,7 +40,10 @@ _IDENTIFIER_FIELDS = frozenset(
     {
         "account_id",
         "channel_id",
+        "interaction_id",
+        "message_id",
         "recipient_id",
+        "reply_token",
         "sender_id",
         "session_id",
         "user_id",
@@ -75,6 +79,11 @@ _RESERVED_FIELDS = frozenset(
 )
 
 
+def elapsed_ms(started_at: float) -> float:
+    """Return elapsed monotonic time in milliseconds."""
+    return (time.monotonic() - started_at) * 1000
+
+
 def _stable_hash(value: Identifier) -> str:
     if value is None:
         return ""
@@ -85,9 +94,14 @@ def _stable_hash(value: Identifier) -> str:
     return f"sha256:{digest}"
 
 
+def hash_identifier(identifier: Identifier) -> str:
+    """Return a stable pseudonym for an identifier used in log correlation."""
+    return _stable_hash(identifier)
+
+
 def hash_account_id(account_id: Identifier) -> str:
     """Return a stable pseudonym for a platform account identifier."""
-    return _stable_hash(account_id)
+    return hash_identifier(account_id)
 
 
 def hash_email(email: str | None) -> str:

--- a/tests/gateways/test_facebook_webhook.py
+++ b/tests/gateways/test_facebook_webhook.py
@@ -19,6 +19,8 @@
 #
 
 import asyncio
+import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -87,7 +89,9 @@ def test_handle_facebook_messages_skips_nonprocessable_messages(
     assert facebook_webhook.PROCESSED_MESSAGES == expected_processed_messages
 
 
-def test_handle_facebook_messages_routes_new_message_to_background_task(monkeypatch):
+def test_handle_facebook_messages_routes_new_message_to_background_task(
+    monkeypatch, capsys
+):
     processed = []
 
     async def fake_process(sender_id, text, mid):
@@ -124,6 +128,12 @@ def test_handle_facebook_messages_routes_new_message_to_background_task(monkeypa
 
     assert facebook_webhook.PROCESSED_MESSAGES == {"mid-1": 123.0}
     assert processed == [("sender-1", "hello", "mid-1")]
+    entry = json.loads(capsys.readouterr().err)
+    assert entry["event"] == "request_received"
+    assert entry["correlation_id"].startswith("sha256:")
+    assert "sender-1" not in json.dumps(entry)
+    assert "mid-1" not in json.dumps(entry)
+    assert "hello" not in json.dumps(entry)
 
 
 @pytest.mark.parametrize(
@@ -163,12 +173,12 @@ def test_get_member_mapping_handles_csv_sources(
     ],
 )
 def test_process_message_task_handles_no_response_reactions(
-    monkeypatch, mid, reaction_emoji, expected_reactions
+    monkeypatch, capsys, mid, reaction_emoji, expected_reactions
 ):
     typing_calls = []
     reactions = []
 
-    async def fake_typing(recipient_id, action):
+    async def fake_typing(recipient_id, action, _correlation_id=None):
         typing_calls.append((recipient_id, action))
 
     async def fake_agent(**_kwargs):
@@ -187,7 +197,7 @@ def test_process_message_task_handles_no_response_reactions(
     monkeypatch.setattr(
         facebook_webhook,
         "send_reaction",
-        lambda sender_id, message_id, emoji: reactions.append(
+        lambda sender_id, message_id, emoji, _correlation_id=None: reactions.append(
             (sender_id, message_id, emoji)
         ),
     )
@@ -213,3 +223,39 @@ def test_process_message_task_handles_no_response_reactions(
         ("sender-1", "typing_off"),
     ]
     assert reactions == expected_reactions
+    entries = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    assert [entry["event"] for entry in entries] == ["agent_invoked", "no_response"]
+    assert "sender-1" not in json.dumps(entries)
+    assert "hello" not in json.dumps(entries)
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_event", "expected_status"),
+    [
+        pytest.param(200, "reply_sent", "success", id="success"),
+        pytest.param(500, "external_send_failure", "failure", id="http-failure"),
+    ],
+)
+def test_send_message_emits_correlated_redacted_result(
+    monkeypatch, capsys, status_code, expected_event, expected_status
+):
+    monkeypatch.setattr(
+        facebook_webhook.requests,
+        "post",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            status_code=status_code,
+            text="private response body",
+        ),
+    )
+
+    facebook_webhook.send_message(
+        "sender-1", "private reply", correlation_id="sha256:correlation"
+    )
+
+    entry = json.loads(capsys.readouterr().err)
+    assert entry["event"] == expected_event
+    assert entry["status"] == expected_status
+    assert entry["correlation_id"] == "sha256:correlation"
+    assert "sender-1" not in json.dumps(entry)
+    assert "private reply" not in json.dumps(entry)
+    assert "private response body" not in json.dumps(entry)

--- a/tests/gateways/test_line_webhook.py
+++ b/tests/gateways/test_line_webhook.py
@@ -19,6 +19,7 @@
 #
 
 import asyncio
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -38,7 +39,7 @@ def _event(text, *, group_id=None):
     )
 
 
-def test_handle_line_message_skips_non_whitelisted_group(monkeypatch):
+def test_handle_line_message_skips_non_whitelisted_group(monkeypatch, capsys):
     monkeypatch.setattr(line_webhook, "LINE_ALLOWED_GROUPS", ["allowed-group"])
     monkeypatch.setattr(
         line_webhook.line_bot_api,
@@ -63,6 +64,11 @@ def test_handle_line_message_skips_non_whitelisted_group(monkeypatch):
     )
 
     assert line_webhook.handle_line_message(_event("hello", group_id="blocked")) is None
+    entry = json.loads(capsys.readouterr().err)
+    assert entry["event"] == "request_ignored"
+    assert entry["status"] == "unauthorized"
+    assert "blocked" not in json.dumps(entry)
+    assert "user-1" not in json.dumps(entry)
 
 
 @pytest.mark.parametrize("text", ["", "   "])
@@ -124,7 +130,9 @@ def _stub_line_task(monkeypatch, agent_result):
         ),
     ],
 )
-def test_process_line_message_task_skips_no_reply_results(monkeypatch, agent_result):
+def test_process_line_message_task_skips_no_reply_results(
+    monkeypatch, capsys, agent_result
+):
     replies, history = _stub_line_task(monkeypatch, agent_result)
 
     asyncio.run(
@@ -135,9 +143,13 @@ def test_process_line_message_task_skips_no_reply_results(monkeypatch, agent_res
 
     assert replies == []
     assert history == []
+    entries = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    assert [entry["event"] for entry in entries] == ["agent_invoked", "no_response"]
+    assert "user-1" not in json.dumps(entries)
+    assert "hello" not in json.dumps(entries)
 
 
-def test_process_line_message_task_replies_with_message_chunks(monkeypatch):
+def test_process_line_message_task_replies_with_message_chunks(monkeypatch, capsys):
     response = "x" * 2001
     replies, history = _stub_line_task(
         monkeypatch,
@@ -155,3 +167,42 @@ def test_process_line_message_task_replies_with_message_chunks(monkeypatch):
     assert token == "reply-token"
     assert [message.text for message in messages] == ["x" * 2000, "x"]
     assert history == [("user-1", "Alice", "hello", response, "LINE")]
+    entries = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    assert [entry["event"] for entry in entries] == ["agent_invoked", "reply_sent"]
+    assert entries[-1]["message_count"] == 2
+    assert "user-1" not in json.dumps(entries)
+    assert "hello" not in json.dumps(entries)
+
+
+def test_process_line_message_task_logs_reply_failure_without_private_data(
+    monkeypatch, capsys
+):
+    _replies, history = _stub_line_task(
+        monkeypatch,
+        AgentMessageResult(text="private agent reply", should_reply=True),
+    )
+    monkeypatch.setattr(
+        line_webhook.line_bot_api,
+        "reply_message",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("private LINE detail")),
+    )
+
+    asyncio.run(
+        line_webhook.process_line_message_task(
+            "reply-token", "user-1", "private question", "chat-1", "1on1"
+        )
+    )
+
+    assert history == []
+    entries = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    assert entries[-1]["event"] == "external_send_failure"
+    assert entries[-1]["error_type"] == "RuntimeError"
+    for sensitive in (
+        "reply-token",
+        "user-1",
+        "chat-1",
+        "private question",
+        "private agent reply",
+        "private LINE detail",
+    ):
+        assert sensitive not in json.dumps(entries)

--- a/tests/services/test_agent_lifecycle_logging.py
+++ b/tests/services/test_agent_lifecycle_logging.py
@@ -1,0 +1,102 @@
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (c) 2026 NTU AI Club
+#
+# This file is part of Ian, an open-source AI agent framework developed
+# and maintained by NTU AI Club.
+#
+# Ian is licensed under the GNU General Public License, either version 3
+# of the License, or (at your option) any later version.
+#
+# Ian is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ian. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import asyncio
+import json
+
+from ian.services.agent import callbacks, sessions, usage
+
+
+def test_agent_callbacks_redact_tool_payloads_and_error_messages(monkeypatch):
+    recorded = []
+    monkeypatch.setattr(
+        callbacks,
+        "add_log",
+        lambda log_type, **fields: recorded.append({"type": log_type, **fields}),
+    )
+    handler = callbacks.DiscordLogCallbackHandler()
+
+    handler.on_tool_start({"name": "lookup"}, "private tool arguments")
+    handler.on_tool_end("private tool result", name="lookup")
+    handler.on_tool_error(RuntimeError("private error detail"))
+
+    assert recorded == [
+        {
+            "type": "TOOL_CALL",
+            "tool_name": "lookup",
+            "args": "[REDACTED content_length=22]",
+        },
+        {
+            "type": "TOOL_RESULT",
+            "tool_name": "lookup",
+            "result": "[REDACTED content_length=19]",
+        },
+        {
+            "type": "ERROR",
+            "error": "RuntimeError",
+            "context": "Tool execution",
+        },
+    ]
+    assert handler.tool_results == ["private tool result"]
+
+
+def test_usage_logs_counts_without_exposing_user_id(monkeypatch, capsys):
+    monkeypatch.setattr(usage, "usage_tracker", {})
+    monkeypatch.setattr(usage, "DAILY_LIMIT", 2)
+
+    assert usage.check_and_update_usage("private-user-id") is True
+    assert usage.check_and_update_usage("private-user-id") is True
+    assert usage.check_and_update_usage("private-user-id") is False
+
+    entries = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    assert [entry["event"] for entry in entries] == [
+        "usage_updated",
+        "usage_updated",
+        "usage_limit_reached",
+    ]
+    assert [entry["usage_count"] for entry in entries] == [1, 2, 2]
+    assert "private-user-id" not in json.dumps(entries)
+
+
+def test_session_lifecycle_logs_without_exposing_identity(monkeypatch, capsys):
+    monkeypatch.setattr(sessions, "sessions", {})
+
+    _session, created = sessions.upsert_session(
+        "private-session-id",
+        "Private Name",
+        "member",
+        "private-channel-id",
+        1.0,
+    )
+    sessions.clear_session_if_timeout(
+        "private-session-id", 1.0 + sessions.TIMEOUT_SECONDS + 1
+    )
+    asyncio.run(sessions.clear_session("private-session-id"))
+
+    assert created is True
+    entries = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    assert [entry["event"] for entry in entries] == [
+        "session_created",
+        "session_expired",
+        "session_clear_skipped",
+    ]
+    serialized = json.dumps(entries)
+    for sensitive in ("private-session-id", "Private Name", "private-channel-id"):
+        assert sensitive not in serialized

--- a/tests/services/test_agent_url_validation.py
+++ b/tests/services/test_agent_url_validation.py
@@ -18,7 +18,14 @@
 # along with Ian. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import asyncio
+import json
+
+import pytest
+
 from ian.domain.urls import URL_PLACEHOLDER
+from ian.domain.injection import INJECTION_REJECTION_MSG
+from ian.services.agent import runtime
 from ian.services.agent.runtime import _validate_agent_response_urls
 
 
@@ -46,3 +53,74 @@ def test_agent_runtime_replaces_hallucinated_urls_without_prompt_wrappers():
     assert "https://linktr.ee/ntuai" in cleaned
     assert "https://fake.example/path" not in cleaned
     assert URL_PLACEHOLDER in cleaned
+
+
+def test_chat_with_agent_logs_blocked_request_without_private_content(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr(runtime, "lookup_member_by_platform", lambda *_args: None)
+    monkeypatch.setattr(runtime, "detect_prompt_injection", lambda _question: True)
+    monkeypatch.setattr(runtime, "add_log", lambda *_args, **_kwargs: None)
+
+    result = asyncio.run(
+        runtime.chat_with_agent(
+            "session-1",
+            "Private Name",
+            "private malicious prompt",
+            "member",
+            0.0,
+            "channel-1",
+            platform="LINE",
+            account_id="account-1",
+        )
+    )
+
+    assert result == INJECTION_REJECTION_MSG
+    entry = json.loads(capsys.readouterr().err)
+    assert entry["event"] == "request_rejected"
+    assert entry["reason"] == "prompt_injection"
+    for sensitive in ("session-1", "account-1", "Private Name", "private malicious prompt"):
+        assert sensitive not in json.dumps(entry)
+
+
+@pytest.mark.parametrize(
+    ("usage_allowed", "expected_event", "expected_status"),
+    [
+        pytest.param(False, "no_response", "rate_limited", id="usage-limit"),
+        pytest.param(True, "agent_invoked", "queued", id="queued"),
+    ],
+)
+def test_chat_with_agent_logs_usage_and_queue_outcomes(
+    monkeypatch, capsys, usage_allowed, expected_event, expected_status
+):
+    queued = []
+
+    async def resolve_future(_future):
+        return "agent result"
+
+    monkeypatch.setattr(runtime, "lookup_member_by_platform", lambda *_args: None)
+    monkeypatch.setattr(runtime, "detect_prompt_injection", lambda _question: False)
+    monkeypatch.setattr(
+        runtime, "check_and_update_usage", lambda _session_id: usage_allowed
+    )
+    monkeypatch.setattr(runtime.request_queue, "put", queued.append)
+    monkeypatch.setattr(runtime.asyncio, "wrap_future", resolve_future)
+
+    asyncio.run(
+        runtime.chat_with_agent(
+            "session-1",
+            "Private Name",
+            "private question",
+            "member",
+            0.0,
+            "channel-1",
+            platform="Discord",
+            account_id="account-1",
+        )
+    )
+
+    entry = json.loads(capsys.readouterr().err)
+    assert entry["event"] == expected_event
+    assert entry["status"] == expected_status
+    assert len(queued) == int(usage_allowed)
+    assert "private question" not in json.dumps(entry)

--- a/tests/services/test_discord_api.py
+++ b/tests/services/test_discord_api.py
@@ -149,5 +149,9 @@ def test_agent_logging_uses_shared_client_for_failure(monkeypatch, capsys):
     agent_logging._send_log_to_discord_sync({"type": "INFO", "message": "hello"})
 
     assert calls == [(123, "```\n[] INFO\n└─ hello\n```")]
-    captured = capsys.readouterr()
-    assert "Failed to send log to Discord: 500 - boom" in captured.err
+    log_entry = json.loads(capsys.readouterr().err)
+    assert log_entry["event"] == "external_send_failure"
+    assert log_entry["operation"] == "send_agent_log"
+    assert log_entry["http_status"] == 500
+    assert "123" not in json.dumps(log_entry)
+    assert "boom" not in json.dumps(log_entry)

--- a/tests/services/test_member_store_lookup_reload.py
+++ b/tests/services/test_member_store_lookup_reload.py
@@ -18,6 +18,7 @@
 # along with Ian. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import json
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -139,3 +140,41 @@ def test_get_member_role_handles_member_status_and_tiers(
 
     assert member_store.get_member_role("Discord", "discord-1") == expected_role
     assert calls == [("Discord", "discord-1")]
+
+
+def test_sync_member_data_logs_started_and_completed_without_member_details(
+    monkeypatch, tmp_path, capsys
+):
+    cache = member_store.MemberCache(tmp_path / "members.json")
+    members = [_valid_member()]
+    monkeypatch.setattr(member_store, "_cache", cache)
+    monkeypatch.setattr(member_store, "fetch_members", lambda *_args: members)
+
+    assert member_store.sync_member_data() is True
+
+    entries = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    assert [entry["event"] for entry in entries] == ["job_started", "job_completed"]
+    assert entries[-1]["member_count"] == 1
+    assert "alice@example.com" not in json.dumps(entries)
+    assert "discord-1" not in json.dumps(entries)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(member_store.MemberApiError("private API detail"), id="api-error"),
+        pytest.param(RuntimeError("private runtime detail"), id="unexpected-error"),
+    ],
+)
+def test_sync_member_data_logs_error_type_without_message(monkeypatch, capsys, error):
+    def fail(*_args):
+        raise error
+
+    monkeypatch.setattr(member_store, "fetch_members", fail)
+
+    assert member_store.sync_member_data() is False
+
+    entries = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    assert entries[-1]["event"] == "job_failed"
+    assert entries[-1]["error_type"] == type(error).__name__
+    assert str(error) not in json.dumps(entries)

--- a/tests/services/test_member_store_updates.py
+++ b/tests/services/test_member_store_updates.py
@@ -18,6 +18,7 @@
 # along with Ian. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import json
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -217,7 +218,12 @@ def test_bind_email_continues_when_local_cache_save_fails(
 
     assert result["success"] is True
     assert cache.find_by_email("alice@example.test")["discord_acc_id"] == "discord-new"
-    assert "Failed to save local DB after binding: disk full" in capsys.readouterr().err
+    entry = json.loads(capsys.readouterr().err)
+    assert entry["event"] == "operation_failed"
+    assert entry["operation"] == "save_member_cache"
+    assert entry["source"] == "bind_email"
+    assert entry["error_type"] == "OSError"
+    assert "disk full" not in json.dumps(entry)
 
 
 @pytest.mark.parametrize(
@@ -363,7 +369,12 @@ def test_update_subscribe_continues_when_local_cache_save_fails(
 
     assert result["success"] is True
     assert cache.find_by_email("alice@example.test")["subscribe"] == "discord"
-    assert "Failed to save local DB after update: disk full" in capsys.readouterr().err
+    entry = json.loads(capsys.readouterr().err)
+    assert entry["event"] == "operation_failed"
+    assert entry["operation"] == "save_member_cache"
+    assert entry["source"] == "update_member_field"
+    assert entry["error_type"] == "OSError"
+    assert "disk full" not in json.dumps(entry)
 
 
 def test_update_personal_prompt_rejects_missing_member(monkeypatch, install_cache):

--- a/tests/services/test_rag.py
+++ b/tests/services/test_rag.py
@@ -19,6 +19,7 @@
 #
 
 import hashlib
+import json
 
 import pytest
 from langchain_core.documents import Document
@@ -34,8 +35,8 @@ def reset_rag_helper_state(monkeypatch):
     monkeypatch.setattr(rag, "bm25_corpus", [])
     monkeypatch.setattr(rag, "bm25_docs", [])
     yield
-    rag.load_jsonl_data.cache_clear()
-    rag.load_markdown_data.cache_clear()
+    getattr(rag.load_jsonl_data, "cache_clear", lambda: None)()
+    getattr(rag.load_markdown_data, "cache_clear", lambda: None)()
 
 
 def test_simple_bm25_scores_matching_document_higher():
@@ -246,3 +247,74 @@ def test_compute_source_hash_uses_existing_files_only(
 
     expected_content = (jsonl_content or b"") + (markdown_content or b"")
     assert result == hashlib.md5(expected_content).hexdigest()
+
+
+def _stub_rag_initialization(monkeypatch):
+    monkeypatch.setattr(rag.jieba, "initialize", lambda: None)
+    monkeypatch.setattr(rag, "HuggingFaceEmbeddings", lambda **_kwargs: object())
+    monkeypatch.setattr(rag, "_compute_source_hash", lambda *_args: "source-hash")
+    monkeypatch.setattr(rag, "_get_saved_hash", lambda: "source-hash")
+    monkeypatch.setattr(rag.os.path, "exists", lambda _path: True)
+    monkeypatch.setattr(rag, "load_jsonl_data", lambda _path: [])
+    monkeypatch.setattr(rag, "load_markdown_data", lambda _path: "")
+    monkeypatch.setattr(
+        rag,
+        "create_enhanced_documents",
+        lambda *_args: [_document("cached", "cached document")],
+    )
+    monkeypatch.setattr(rag, "build_bm25_index", lambda: None)
+    monkeypatch.setattr(rag, "_try_move_faiss_to_gpu", lambda: False)
+
+
+def test_initialize_rag_system_logs_cache_success(monkeypatch, capsys):
+    _stub_rag_initialization(monkeypatch)
+    monkeypatch.setattr(rag, "_try_load_faiss_index", lambda: True)
+
+    assert rag.initialize_rag_system() is True
+
+    entries = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    assert [entry["event"] for entry in entries] == ["job_started", "job_completed"]
+    assert entries[-1]["source"] == "cache"
+    assert entries[-1]["document_count"] == 1
+
+
+def test_initialize_rag_system_logs_embedding_failure_without_error_message(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr(rag.jieba, "initialize", lambda: None)
+    monkeypatch.setattr(
+        rag,
+        "HuggingFaceEmbeddings",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("private model detail")),
+    )
+
+    assert rag.initialize_rag_system() is False
+
+    entries = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    assert entries[-1]["event"] == "job_failed"
+    assert entries[-1]["stage"] == "embedding_model"
+    assert entries[-1]["error_type"] == "RuntimeError"
+    assert "private model detail" not in json.dumps(entries)
+
+
+def test_initialize_rag_system_logs_tokenizer_failure(monkeypatch, capsys):
+    monkeypatch.setattr(
+        rag.jieba,
+        "initialize",
+        lambda: (_ for _ in ()).throw(RuntimeError("private tokenizer detail")),
+    )
+    monkeypatch.setattr(
+        rag,
+        "HuggingFaceEmbeddings",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("embedding should not be initialized")
+        ),
+    )
+
+    assert rag.initialize_rag_system() is False
+
+    entries = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    assert entries[-1]["event"] == "job_failed"
+    assert entries[-1]["stage"] == "tokenizer"
+    assert entries[-1]["error_type"] == "RuntimeError"
+    assert "private tokenizer detail" not in json.dumps(entries)

--- a/tests/services/test_reminder_runner.py
+++ b/tests/services/test_reminder_runner.py
@@ -18,7 +18,8 @@
 # along with Ian. If not, see <https://www.gnu.org/licenses/>.
 #
 
-from datetime import datetime, timezone, timedelta
+import json
+from datetime import datetime, timedelta, timezone
 
 import pandas as pd
 import pytest
@@ -62,9 +63,7 @@ def test_run_once_logs_fetch_failure_without_loading_members(monkeypatch):
 
     reminder_runner.run_once(target_date=TARGET_DATE)
 
-    assert logs == [
-        "```\n[REMINDER] FAILED to fetch course data: sheet unavailable\n```"
-    ]
+    assert logs == ["```\n[REMINDER] FAILED to fetch course data\n```"]
 
 
 def test_run_once_with_no_events_does_not_load_members_or_send_messages(monkeypatch):
@@ -89,7 +88,7 @@ def test_run_once_with_no_events_does_not_load_members_or_send_messages(monkeypa
     reminder_runner.run_once(target_date=TARGET_DATE)
 
 
-def test_run_once_dry_run_lists_recipients_without_sending_messages(
+def test_run_once_dry_run_logs_counts_without_recipient_details(
     monkeypatch, capsys
 ):
     members = [{"name": "Alice"}, {"name": "Bob"}]
@@ -117,10 +116,13 @@ def test_run_once_dry_run_lists_recipients_without_sending_messages(
 
     reminder_runner.run_once(target_date=TARGET_DATE, dry=True)
 
-    captured = capsys.readouterr()
-    assert "Would notify 2 member(s)" in captured.err
-    assert "Alice (Discord)" in captured.err
-    assert "Bob (Discord)" in captured.err
+    entries = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    completed = entries[-1]
+    assert completed["event"] == "job_completed"
+    assert completed["status"] == "dry_run"
+    assert completed["recipient_count"] == 2
+    assert "Alice" not in json.dumps(entries)
+    assert "discord-1" not in json.dumps(entries)
 
 
 def test_run_once_sends_personalized_messages_and_reports_counts(monkeypatch):
@@ -190,12 +192,41 @@ def test_run_once_logs_member_load_failure_without_sending_messages(monkeypatch)
 
     reminder_runner.run_once(target_date=TARGET_DATE)
 
-    assert logs == [
-        "```\n[REMINDER] FAILED to load member data: invalid member JSON\n```"
-    ]
+    assert logs == ["```\n[REMINDER] FAILED to load member data\n```"]
 
 
-def test_run_once_continues_after_one_dm_raises(monkeypatch):
+@pytest.mark.parametrize("failure_stage", ["find_events", "format_message"])
+def test_run_once_logs_event_preparation_failures(
+    monkeypatch, capsys, failure_stage
+):
+    logs = []
+    monkeypatch.setattr(reminder_runner, "fetch_course_data", pd.DataFrame)
+    monkeypatch.setattr(reminder_runner, "send_log", logs.append)
+    if failure_stage == "find_events":
+        monkeypatch.setattr(
+            reminder_runner,
+            "find_events_on_date",
+            lambda *_args: (_ for _ in ()).throw(ValueError("private event detail")),
+        )
+    else:
+        monkeypatch.setattr(reminder_runner, "find_events_on_date", lambda *_: EVENTS)
+        monkeypatch.setattr(
+            reminder_runner,
+            "format_reminder_message",
+            lambda *_args: (_ for _ in ()).throw(ValueError("private event detail")),
+        )
+
+    reminder_runner.run_once(target_date=TARGET_DATE)
+
+    entries = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    assert entries[-1]["event"] == "job_failed"
+    assert entries[-1]["stage"] == "prepare_events"
+    assert entries[-1]["error_type"] == "ValueError"
+    assert "private event detail" not in json.dumps(entries)
+    assert logs == ["```\n[REMINDER] FAILED to prepare event data\n```"]
+
+
+def test_run_once_continues_after_one_dm_raises(monkeypatch, capsys):
     bound = [
         {"name": "Alice", "email": "alice@example.test", "discord_id": "bad"},
         {"name": "Bob", "email": "bob@example.test", "discord_id": "good"},
@@ -218,6 +249,13 @@ def test_run_once_continues_after_one_dm_raises(monkeypatch):
 
     assert attempted == ["bad", "good"]
     assert "Discord: 1 sent, 1 failed" in logs[0]
+    entries = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    failure = next(
+        entry for entry in entries if entry["event"] == "external_send_failure"
+    )
+    assert failure["error_type"] == "TimeoutError"
+    assert "bad" not in json.dumps(entries)
+    assert "Discord timeout" not in json.dumps(entries)
 
 
 def test_run_once_with_no_recipients_reports_zero_counts(monkeypatch):

--- a/tests/services/test_service_supervisor.py
+++ b/tests/services/test_service_supervisor.py
@@ -18,6 +18,10 @@
 # along with Ian. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import json
+
+import pytest
+
 from ian.services.service_supervisor import build_serve_commands, serve_all
 
 
@@ -51,7 +55,7 @@ def test_build_serve_commands_uses_cli_subcommands_in_startup_order():
     ]
 
 
-def test_serve_all_waits_for_mcp_before_starting_other_services():
+def test_serve_all_waits_for_mcp_before_starting_other_services(capsys):
     started = []
     health_checks = []
     processes = [FakeProcess(), FakeProcess(), FakeProcess(), FakeProcess(returncode=0)]
@@ -89,3 +93,43 @@ def test_serve_all_waits_for_mcp_before_starting_other_services():
         ["ian", "discord"],
     ]
     assert [process.terminated for process in processes] == [True, True, True, False]
+    entries = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    assert [entry["event"] for entry in entries] == [
+        "job_started",
+        "service_started",
+        "health_wait_started",
+        "service_ready",
+        "service_started",
+        "service_started",
+        "service_started",
+        "job_failed",
+    ]
+    assert [entry["service"] for entry in entries if "service" in entry] == [
+        "mcp",
+        "mcp",
+        "mcp",
+        "webhook",
+        "reminder",
+        "discord",
+        "discord",
+    ]
+    assert entries[-1]["status"] == "unexpected_exit"
+
+
+def test_serve_all_logs_health_failure_and_stops_started_process(capsys):
+    process = FakeProcess()
+
+    def fail_health(_url, _timeout):
+        raise TimeoutError("private health URL")
+
+    with pytest.raises(TimeoutError, match="private health URL"):
+        serve_all(
+            popen_factory=lambda _command: process,
+            wait_for_http=fail_health,
+        )
+
+    entries = [json.loads(line) for line in capsys.readouterr().err.splitlines()]
+    assert entries[-1]["event"] == "job_failed"
+    assert entries[-1]["error_type"] == "TimeoutError"
+    assert "private health URL" not in json.dumps(entries)
+    assert process.terminated is True

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -28,8 +28,10 @@ from ian.config import TZ_TPE
 from ian.utils.logging import (
     REDACTED,
     StructuredLogger,
+    elapsed_ms,
     hash_account_id,
     hash_email,
+    hash_identifier,
     log_event,
     redact_token,
     redact_user_content,
@@ -137,6 +139,16 @@ def test_email_hashing_is_case_insensitive():
 def test_account_id_hashing_accepts_numeric_and_missing_identifiers():
     assert hash_account_id(12345).startswith("sha256:")
     assert hash_account_id(None) == ""
+
+
+def test_generic_identifier_hash_matches_account_hashing_policy():
+    assert hash_identifier("identifier-1") == hash_account_id("identifier-1")
+
+
+def test_elapsed_ms_uses_monotonic_clock(monkeypatch):
+    monkeypatch.setattr("ian.utils.logging.time.monotonic", lambda: 12.345)
+
+    assert elapsed_ms(10.0) == pytest.approx(2345.0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Standardize lifecycle event logs across gateway, agent, reminder, member sync, RAG, and service supervision flows. Structured fields are sanitized consistently so logs retain operational correlation without exposing raw message content, tokens, emails, or platform identifiers.

## Related Issue

Fixes #91
Part of #89

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Configuration or deployment
- [x] Tests

## Changes

- Add consistent request, agent, reply, failure, job, and service lifecycle events with component, status, duration, and correlation fields.
- Apply centralized identifier hashing and content/token redaction to structured logs and Discord agent-log inputs.
- Cover gateway branches, agent callbacks and sessions, reminder failures, member synchronization, RAG initialization, and supervisor exits with table-driven edge-case tests.

## Testing

- [x] Local tests or checks pass
- [ ] Manual verification completed
- [ ] Not tested; reason:

Commands run:

- `make test` — 277 passed
- `make precommit` — all hooks passed
- `git diff --check` — passed

## Impact Checklist

- [x] Discord bot behavior checked, if affected
- [ ] MCP server behavior checked, if affected
- [x] Webhook behavior checked, if affected
- [ ] Docker or compose changes checked, if affected
- [ ] Environment variables documented, if changed
- [x] Logs do not expose secrets or sensitive data

## Notes for Reviewers

Validation uses mocked platform boundaries; no live Discord, Facebook, or LINE messages were sent. Discord log-channel terminal formatting is unchanged, while raw user/tool/agent content is now redacted and identifiers are pseudonymized.
